### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "nyc": "^13.0.0",
     "power-assert": "^1.4.4",
     "prettier": "^1.7.4",
-    "through2": "^3.0.0"
+    "through2": "^3.0.0",
+    "@types/sinon": "5.0.5"
   }
 }


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.