### PR TITLE
refactor: improve the sample tests

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,5 @@
 {
   "name": "nodejs-docs-samples-conversation",
-  "version": "0.0.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Google LLC",
@@ -13,18 +12,18 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "mocha system-test/*.test.js --timeout=600000"
+    "test": "mocha system-test --timeout=600000"
   },
   "dependencies": {
     "dialogflow": "^0.7.0",
     "pump": "^3.0.0",
     "through2": "^3.0.0",
-    "prompt": "^1.0.0",
     "yargs": "^12.0.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.0.0",
+    "chai": "^4.2.0",
+    "execa": "^1.0.0",
     "mocha": "^5.2.0"
   }
 }

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -16,37 +16,40 @@
 'use strict';
 
 const path = require('path');
-const assert = require('assert');
-const {runAsync} = require('@google-cloud/nodejs-repo-tools');
+const {assert} = require('chai');
+const execa = require('execa');
 
 const cmd = 'node detect.js';
 const cwd = path.join(__dirname, '..');
+
 const audioFilepathBookARoom = path
   .join(__dirname, '../resources/book_a_room.wav')
   .replace(/(\s+)/g, '\\$1');
 
-it('Should detect text queries', async () => {
-  const output = await runAsync(`${cmd} text -q "hello"`, cwd);
-  assert.strictEqual(output.includes('Detected intent'), true);
-});
+describe('basic detection', () => {
+  it('should detect text queries', async () => {
+    const {stdout} = await execa.shell(`${cmd} text -q "hello"`, {cwd});
+    assert.include(stdout, 'Detected intent');
+  });
 
-it('Should detect event query', async () => {
-  const output = await runAsync(`${cmd} event WELCOME`, cwd);
-  assert.strictEqual(output.includes('Query: WELCOME'), true);
-});
+  it('should detect event query', async () => {
+    const {stdout} = await execa.shell(`${cmd} event WELCOME`, {cwd});
+    assert.include(stdout, 'Query: WELCOME');
+  });
 
-it('Should detect audio query', async () => {
-  const output = await runAsync(
-    `${cmd} audio ${audioFilepathBookARoom} -r 16000`,
-    cwd
-  );
-  assert.strictEqual(output.includes('Detected intent'), true);
-});
+  it('should detect audio query', async () => {
+    const {stdout} = await execa.shell(
+      `${cmd} audio ${audioFilepathBookARoom} -r 16000`,
+      {cwd}
+    );
+    assert.include(stdout, 'Detected intent');
+  });
 
-it('Should detect audio query in streaming fashion', async () => {
-  const output = await runAsync(
-    `${cmd} stream ${audioFilepathBookARoom} -r 16000`,
-    cwd
-  );
-  assert.strictEqual(output.includes('Detected intent'), true);
+  it('should detect audio query in streaming fashion', async () => {
+    const {stdout} = await execa.shell(
+      `${cmd} stream ${audioFilepathBookARoom} -r 16000`,
+      {cwd}
+    );
+    assert.include(stdout, 'Detected intent');
+  });
 });


### PR DESCRIPTION
This changes a few things:
- Use the chai `assert.include` assertion instead of ok
- Use `execa` instead of `nodejs-repo-tools`
- Split the giant test methods into single purpose tests
- Adds unique identifiers to a few places 