### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [0.9.0](https://www.github.com/googleapis/nodejs-dialogflow/compare/v0.8.2...v0.9.0) (2019-05-07)
 
+### BREAKING CHANGE
+
+This release drops support for node versions below v8.10.0.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 [1]: https://www.npmjs.com/package/dialogflow?activeTab=versions
 
+## [0.9.0](https://www.github.com/googleapis/nodejs-dialogflow/compare/v0.8.2...v0.9.0) (2019-05-07)
+
+
+### Bug Fixes
+
+* include 'x-goog-request-params' header in requests ([#310](https://www.github.com/googleapis/nodejs-dialogflow/issues/310)) ([479defe](https://www.github.com/googleapis/nodejs-dialogflow/commit/479defe))
+* **deps:** update dependency google-gax to ^0.26.0 ([#326](https://www.github.com/googleapis/nodejs-dialogflow/issues/326)) ([7541e5f](https://www.github.com/googleapis/nodejs-dialogflow/commit/7541e5f))
+
+
+### Build System
+
+* upgrade engines field to >=8.10.0 ([#328](https://www.github.com/googleapis/nodejs-dialogflow/issues/328)) ([62f144f](https://www.github.com/googleapis/nodejs-dialogflow/commit/62f144f))
+
+
+### Features
+
+* add the `updateDocument and `reloadDocument` methods ([#315](https://www.github.com/googleapis/nodejs-dialogflow/issues/315)) ([6e2defe](https://www.github.com/googleapis/nodejs-dialogflow/commit/6e2defe))
+* support audio config ([4ecea0e](https://www.github.com/googleapis/nodejs-dialogflow/commit/4ecea0e))
+
+
+### BREAKING CHANGES
+
+* upgrade engines field to >=8.10.0 (#328)
+
 ## v0.8.2
 
 03-13-2019 16:30 PDT
@@ -165,4 +189,3 @@ Version v0.6.0 of the Dialogflow NodeJS Client Library brings with it these chan
 - chore(build): synth.py: npm ci; node templates
 - chore(deps): update node:10 docker digest to 1201e1 (#96)
 - Regenerate GAPIC for V1 and V2Beta1 using synth.py (#110)
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dialogflow",
   "description": "Dialogflow API client for Node.js",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,7 +15,7 @@
     "test": "mocha system-test --timeout=600000"
   },
   "dependencies": {
-    "dialogflow": "^0.8.2",
+    "dialogflow": "^0.9.0",
     "pb-util": "^0.1.0",
     "pump": "^3.0.0",
     "through2": "^3.0.0",


### PR DESCRIPTION
# BREAKING CHANGE: dropping support for node <8.10