### PR TITLE
chore: add .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "dialogflow",
+  "name_pretty": "Dialogflow API",
+  "product_documentation": "https://cloud.google.com/dialogflow-enterprise/",
+  "client_documentation": "https://cloud.google.com/dialogflow-enterprise/docs/reference/rpc/",
+  "issue_tracker": "https://issuetracker.google.com/savedsearches/5300385",
+  "release_level": "beta",
+  "language": "nodejs",
+  "repo": "googleapis/nodejs-dialogflow",
+  "distribution_name": "dialogflow",
+  "api_id": "dialogflow.googleapis.com",
+  "requires_billing": true
+}

--- a/synth.py
+++ b/synth.py
@@ -27,7 +27,7 @@ for version in versions:
 
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library()
-s.copy(templates)
+s.copy(templates, excludes=["README.md", "samples/README.md"])
 
 # dialogflow publishes to npm with no scope.
 s.replace("src/**/*",


### PR DESCRIPTION
This PR adds the `.repo-metadata.json` required by the new docs site.

We're currently excluding the `README.md` and `samples/README.md`, because there are many samples contained in a single `samples/resource.js`.

I've created a tracking ticket to eventually address this: https://github.com/googleapis/nodejs-dialogflow/issues/358