### PR TITLE
refactor: replace `execa` with `execSync` in sample tests

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "dialogflow",
   "name_pretty": "Dialogflow API",
   "product_documentation": "https://cloud.google.com/dialogflow-enterprise/",
-  "client_documentation": "https://cloud.google.com/dialogflow-enterprise/docs/reference/rpc/",
+  "client_documentation": "https://googleapis.dev/nodejs/dialogflow/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5300385",
   "release_level": "beta",
   "language": "nodejs",

--- a/samples/package.json
+++ b/samples/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "execa": "^1.0.0",
     "mocha": "^6.0.0"
   }
 }

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -17,12 +17,10 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const cp = require('child_process');
+const execSync = require('child_process').execSync;
 const cmd = 'node detect.js';
 const cmd_tts = 'node detect-intent-TTS-response.v2.js';
 const cmd_sentiment = 'node detect-intent-sentiment.v2.js';
-const cwd = path.join(__dirname, '..');
-cp.cwd = cwd;
 const projectId =
   process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
 const testQuery = 'Where is my data stored?';
@@ -31,38 +29,34 @@ const audioFilepathBookARoom = path
   .join(__dirname, '../resources/book_a_room.wav')
   .replace(/(\s+)/g, '\\$1');
 
+const exec = cmd => execSync(cmd, {encoding: 'utf8'});
+
 describe('basic detection', () => {
   it('should detect text queries', async () => {
-    const stdout = cp.execSync(`${cmd} text -q "hello"`, {stdio: 'pipe'});
+    const stdout = await exec(`${cmd} text -q "hello"`);
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect event query', async () => {
-    const stdout = cp.execSync(`${cmd} event WELCOME`, {stdio: 'pipe'});
+    const stdout = await exec(`${cmd} event WELCOME`);
     assert.include(stdout, 'Query: WELCOME');
   });
 
   it('should detect audio query', async () => {
-    const stdout = cp.execSync(
-      `${cmd} audio ${audioFilepathBookARoom} -r 16000`,
-      {cwd}
-    );
+    const stdout = await exec(
+      `${cmd} audio ${audioFilepathBookARoom} -r 16000`);
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect audio query in streaming fashion', async () => {
-    const stdout = cp.execSync(
-      `${cmd} stream ${audioFilepathBookARoom} -r 16000`,
-      {cwd}
-    );
+    const stdout = await exec(
+      `${cmd} stream ${audioFilepathBookARoom} -r 16000`);
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect Intent with Text to Speech Response', async () => {
-    const stdout = cp.execSync(
-      `${cmd_tts} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US' './resources/output.wav'`,
-      {cwd}
-    );
+    const stdout = await exec(
+      `${cmd_tts} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US' './resources/output.wav'`);
     assert.include(
       stdout,
       'Audio content written to file: ./resources/output.wav'
@@ -70,9 +64,8 @@ describe('basic detection', () => {
   });
 
   it('should detect sentiment with intent', async () => {
-    const stdout = cp.execSync(
-      `${cmd_sentiment} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US'`,
-      {cwd}
+    const stdout = await exec(
+      `${cmd_sentiment} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US'`
     );
     assert.include(stdout, 'Detected sentiment');
   });

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -33,29 +33,29 @@ const exec = cmd => execSync(cmd, {encoding: 'utf8'});
 
 describe('basic detection', () => {
   it('should detect text queries', async () => {
-    const stdout = await exec(`${cmd} text -q "hello"`);
+    const stdout = exec(`${cmd} text -q "hello"`);
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect event query', async () => {
-    const stdout = await exec(`${cmd} event WELCOME`);
+    const stdout = exec(`${cmd} event WELCOME`);
     assert.include(stdout, 'Query: WELCOME');
   });
 
   it('should detect audio query', async () => {
-    const stdout = await exec(
+    const stdout = exec(
       `${cmd} audio ${audioFilepathBookARoom} -r 16000`);
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect audio query in streaming fashion', async () => {
-    const stdout = await exec(
+    const stdout = exec(
       `${cmd} stream ${audioFilepathBookARoom} -r 16000`);
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect Intent with Text to Speech Response', async () => {
-    const stdout = await exec(
+    const stdout = exec(
       `${cmd_tts} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US' './resources/output.wav'`);
     assert.include(
       stdout,
@@ -64,7 +64,7 @@ describe('basic detection', () => {
   });
 
   it('should detect sentiment with intent', async () => {
-    const stdout = await exec(
+    const stdout = exec(
       `${cmd_sentiment} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US'`
     );
     assert.include(stdout, 'Detected sentiment');

--- a/samples/system-test/detect.test.js
+++ b/samples/system-test/detect.test.js
@@ -17,12 +17,12 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const execa = require('execa');
-
+const cp = require('child_process');
 const cmd = 'node detect.js';
 const cmd_tts = 'node detect-intent-TTS-response.v2.js';
 const cmd_sentiment = 'node detect-intent-sentiment.v2.js';
 const cwd = path.join(__dirname, '..');
+cp.cwd = cwd;
 const projectId =
   process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
 const testQuery = 'Where is my data stored?';
@@ -33,17 +33,17 @@ const audioFilepathBookARoom = path
 
 describe('basic detection', () => {
   it('should detect text queries', async () => {
-    const {stdout} = await execa.shell(`${cmd} text -q "hello"`, {cwd});
+    const stdout = cp.execSync(`${cmd} text -q "hello"`, {stdio: 'pipe'});
     assert.include(stdout, 'Detected intent');
   });
 
   it('should detect event query', async () => {
-    const {stdout} = await execa.shell(`${cmd} event WELCOME`, {cwd});
+    const stdout = cp.execSync(`${cmd} event WELCOME`, {stdio: 'pipe'});
     assert.include(stdout, 'Query: WELCOME');
   });
 
   it('should detect audio query', async () => {
-    const {stdout} = await execa.shell(
+    const stdout = cp.execSync(
       `${cmd} audio ${audioFilepathBookARoom} -r 16000`,
       {cwd}
     );
@@ -51,7 +51,7 @@ describe('basic detection', () => {
   });
 
   it('should detect audio query in streaming fashion', async () => {
-    const {stdout} = await execa.shell(
+    const stdout = cp.execSync(
       `${cmd} stream ${audioFilepathBookARoom} -r 16000`,
       {cwd}
     );
@@ -59,7 +59,7 @@ describe('basic detection', () => {
   });
 
   it('should detect Intent with Text to Speech Response', async () => {
-    const {stdout} = await execa.shell(
+    const stdout = cp.execSync(
       `${cmd_tts} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US' './resources/output.wav'`,
       {cwd}
     );
@@ -70,7 +70,7 @@ describe('basic detection', () => {
   });
 
   it('should detect sentiment with intent', async () => {
-    const {stdout} = await execa.shell(
+    const stdout = cp.execSync(
       `${cmd_sentiment} ${projectId} 'SESSION_ID' '${testQuery}' 'en-US'`,
       {cwd}
     );

--- a/samples/system-test/detect.v2beta1.test.js
+++ b/samples/system-test/detect.v2beta1.test.js
@@ -27,15 +27,7 @@ const testKnowledgeBaseName = `${uuid().split('-')[0]}-TestKnowledgeBase`;
 const testDocName = 'TestDoc';
 const testDocumentPath = 'https://cloud.google.com/storage/docs/faq';
 
-const exec = async cmd => {
-  cp.cwd = cwd;
-  try {
-    const res = cp.execSync(cmd, {stdio: 'pipe'});
-    return res.toString('utf-8');
-  } catch (err) {
-    throw new Error(err.message);
-  }
-};
+const exec = async cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('v2beta1 detection', () => {
   let knowbaseFullName;

--- a/samples/system-test/detect.v2beta1.test.js
+++ b/samples/system-test/detect.v2beta1.test.js
@@ -15,19 +15,16 @@
 
 'use strict';
 
-const path = require('path');
 const {assert} = require('chai');
-const cp = require('child_process');
+const execSync = require('child_process').execSync;
 const uuid = require('uuid/v4');
-
 const cmd = 'node detect.v2beta1.js';
-const {cwd} = path.join(__dirname, '..');
 const testQuery = 'Where is my data stored?';
 const testKnowledgeBaseName = `${uuid().split('-')[0]}-TestKnowledgeBase`;
 const testDocName = 'TestDoc';
 const testDocumentPath = 'https://cloud.google.com/storage/docs/faq';
 
-const exec = async cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const exec = cmd => execSync(cmd, {encoding: 'utf8'});
 
 describe('v2beta1 detection', () => {
   let knowbaseFullName;

--- a/samples/system-test/detect.v2beta1.test.js
+++ b/samples/system-test/detect.v2beta1.test.js
@@ -17,7 +17,7 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const execa = require('execa');
+const cp = require('child_process');
 const uuid = require('uuid/v4');
 
 const cmd = 'node detect.v2beta1.js';
@@ -28,11 +28,13 @@ const testDocName = 'TestDoc';
 const testDocumentPath = 'https://cloud.google.com/storage/docs/faq';
 
 const exec = async cmd => {
-  const res = await execa.shell(cmd, {cwd});
-  if (res.stderr) {
-    throw new Error(res.stderr);
+  cp.cwd = cwd;
+  try {
+    const res = cp.execSync(cmd, {stdio: 'pipe'});
+    return res.toString('utf-8');
+  } catch (err) {
+    throw new Error(err.message);
   }
-  return res.stdout;
 };
 
 describe('v2beta1 detection', () => {

--- a/samples/system-test/detect.v2beta1.test.js
+++ b/samples/system-test/detect.v2beta1.test.js
@@ -33,11 +33,11 @@ describe('v2beta1 detection', () => {
 
   it('should create a knowledge base', async () => {
     // Check that the knowledge base does not yet exist
-    let output = await exec(`${cmd} listKnowledgeBases`);
+    let output = exec(`${cmd} listKnowledgeBases`);
     assert.notInclude(output, testKnowledgeBaseName);
 
     // Creates a knowledge base
-    output = await exec(
+    output = exec(
       `${cmd} createKnowledgeBase -k ${testKnowledgeBaseName}`
     );
     assert.include(output, `displayName: ${testKnowledgeBaseName}`);
@@ -53,58 +53,58 @@ describe('v2beta1 detection', () => {
   });
 
   it('should list the knowledge bases', async () => {
-    const output = await exec(`${cmd} listKnowledgeBases`);
+    const output = exec(`${cmd} listKnowledgeBases`);
     assert.include(output, testKnowledgeBaseName);
   });
 
   it('should get a knowledge base', async () => {
-    const output = await exec(`${cmd} getKnowledgeBase -b "${knowbaseId}"`);
+    const output = exec(`${cmd} getKnowledgeBase -b "${knowbaseId}"`);
     assert.include(output, `displayName: ${testKnowledgeBaseName}`);
     assert.include(output, `name: ${knowbaseFullName}`);
   });
 
   it('should create a document', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} createDocument -n "${knowbaseFullName}" -z "${testDocumentPath}" -m "${testDocName}"`
     );
     assert.include(output, 'Document created');
   });
 
   it('should list documents', async () => {
-    const output = await exec(`${cmd} listDocuments -n "${knowbaseFullName}"`);
+    const output = exec(`${cmd} listDocuments -n "${knowbaseFullName}"`);
     const parsedOut = output.split('\n');
     documentFullPath = parsedOut[parsedOut.length - 1].split(':')[1];
     assert.include(output, `There are 1 documents in ${knowbaseFullName}`);
   });
 
   it('should detect intent with a knowledge base', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} detectIntentKnowledge -q "${testQuery}" -n "${knowbaseId}"`
     );
     assert.include(output, 'Detected Intent:');
   });
 
   it('should delete a document', async () => {
-    const output = await exec(`${cmd} deleteDocument -d ${documentFullPath}`);
+    const output = exec(`${cmd} deleteDocument -d ${documentFullPath}`);
     assert.include(output, 'document deleted');
   });
 
   it('should list the document', async () => {
-    const output = await exec(`${cmd} listDocuments -n "${knowbaseFullName}"`);
+    const output = exec(`${cmd} listDocuments -n "${knowbaseFullName}"`);
     assert.notInclude(output, documentFullPath);
   });
 
   it('should delete the Knowledge Base', async () => {
-    await exec(`${cmd} deleteKnowledgeBase -n "${knowbaseFullName}"`);
+    exec(`${cmd} deleteKnowledgeBase -n "${knowbaseFullName}"`);
   });
 
   it('should list the Knowledge Base', async () => {
-    const output = await exec(`${cmd} listKnowledgeBases`);
+    const output = exec(`${cmd} listKnowledgeBases`);
     assert.notInclude(output, testKnowledgeBaseName);
   });
 
   it('should detect Intent with Model Selection', async () => {
-    const output = await exec(`${cmd} detectIntentwithModelSelection`);
+    const output = exec(`${cmd} detectIntentwithModelSelection`);
     assert.include(
       output,
       'Response: I can help with that. Where would you like to reserve a room?'
@@ -112,7 +112,7 @@ describe('v2beta1 detection', () => {
   });
 
   it('should detect Intent with Text to Speech Response', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} detectIntentwithTexttoSpeechResponse -q "${testQuery}"`
     );
     assert.include(
@@ -122,7 +122,7 @@ describe('v2beta1 detection', () => {
   });
 
   it('should detect sentiment with intent', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} detectIntentandSentiment -q "${testQuery}"`
     );
     assert.include(output, 'Detected sentiment');

--- a/samples/system-test/resource.test.js
+++ b/samples/system-test/resource.test.js
@@ -21,15 +21,7 @@ const cp = require('child_process');
 const uuid = require('uuid');
 
 const cwd = path.join(__dirname, '..');
-const exec = async cmd => {
-  cp.cwd = cwd;
-  try {
-    const res = cp.execSync(cmd, {stdio: 'pipe'});
-    return res.toString('utf-8');
-  } catch (err) {
-    throw new Error(err.message);
-  }
-};
+const exec = async cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('resources', () => {
   const cmd = 'node resource.js';

--- a/samples/system-test/resource.test.js
+++ b/samples/system-test/resource.test.js
@@ -36,7 +36,7 @@ describe('resources', () => {
   let intentId;
 
   it('should create a context', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} create-context -s ${sessionId} -c ${contextName} -l 3`
     );
     assert.include(output, sessionId);
@@ -44,26 +44,26 @@ describe('resources', () => {
   });
 
   it('should list contexts', async () => {
-    const output = await exec(`${cmd} list-contexts -s ${sessionId}`);
+    const output = exec(`${cmd} list-contexts -s ${sessionId}`);
     assert.include(output, sessionId);
     assert.include(output, contextName);
     assert.include(output, '3');
   });
 
   it('should delete a context', async () => {
-    let output = await exec(
+    let output = exec(
       `${cmd} delete-context -s ${sessionId} -c ${contextName}`
     );
     assert.include(output, sessionId);
     assert.include(output, contextName);
 
-    output = await exec(`${cmd} list-contexts -s ${sessionId}`);
+    output = exec(`${cmd} list-contexts -s ${sessionId}`);
     assert.notInclude(output, sessionId);
     assert.notInclude(output, contextName);
   });
 
   it('should create an entity type and entity', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} create-entity-type -d ${displayName} -k KIND_MAP`
     );
     assert.include(output, 'entityTypes');
@@ -71,49 +71,49 @@ describe('resources', () => {
   });
 
   it('should List the Entity Type', async () => {
-    const output = await exec(`${cmd} list-entity-types`);
+    const output = exec(`${cmd} list-entity-types`);
     assert.include(output, displayName);
     assert.include(output, entityTypeId);
   });
 
   it('should Create an Entity for the Entity Type', async () => {
-    await exec(
+    exec(
       `${cmd} create-entity -e ${entityTypeId} -v ${entityName} -s ${synonym1} -s ${synonym2}`
     );
   });
 
   it('should List the Entity', async () => {
-    const output = await exec(`${cmd} list-entities -e ${entityTypeId}`);
+    const output = exec(`${cmd} list-entities -e ${entityTypeId}`);
     assert.include(output, entityName);
     assert.include(output, synonym1);
     assert.include(output, synonym2);
   });
 
   it('should Delete the Entity', async () => {
-    let output = await exec(
+    let output = exec(
       `${cmd} delete-entity -e ${entityTypeId} -v ${entityName}`
     );
     assert.include(output, entityName);
 
     // Verify the Entity is Deleted
-    output = await exec(`${cmd} list-entities -e ${entityTypeId}`);
+    output = exec(`${cmd} list-entities -e ${entityTypeId}`);
     assert.notInclude(output, entityName);
     assert.notInclude(output, synonym1);
     assert.notInclude(output, synonym2);
   });
 
   it('should Delete the Entity Type', async () => {
-    let output = await exec(`${cmd} delete-entity-type -e ${entityTypeId}`);
+    let output = exec(`${cmd} delete-entity-type -e ${entityTypeId}`);
     assert.include(output, entityTypeId);
 
     // Verify the Entity Type is Deleted
-    output = await exec(`${cmd} list-entity-types`);
+    output = exec(`${cmd} list-entity-types`);
     assert.notInclude(output, displayName);
     assert.notInclude(output, entityTypeId);
   });
 
   it('should create an intent', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} create-intent -d ${displayName} -t ${phrase1} -t ${phrase2} -m ${message1} -m ${message2}`
     );
     assert.include(output, 'intents');
@@ -121,21 +121,21 @@ describe('resources', () => {
   });
 
   it('should list the intents', async () => {
-    const output = await exec(`${cmd} list-intents`);
+    const output = exec(`${cmd} list-intents`);
     assert.include(output, intentId);
     assert.include(output, displayName);
   });
 
   it('should delete the intent', async () => {
-    let output = await exec(`${cmd} delete-intent -i ${intentId}`);
+    let output = exec(`${cmd} delete-intent -i ${intentId}`);
     assert.include(output, intentId);
-    output = await exec(`${cmd} list-intents`);
+    output = exec(`${cmd} list-intents`);
     assert.notInclude(output, intentId);
     assert.notInclude(output, displayName);
   });
 
   it('should create a session entity type', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} create-entity-type -d ${displayName} -k KIND_MAP`
     );
     assert.include(output, 'entityTypes');
@@ -143,13 +143,13 @@ describe('resources', () => {
   });
 
   it('should List the Entity Type', async () => {
-    const output = await exec(`${cmd} list-entity-types`);
+    const output = exec(`${cmd} list-entity-types`);
     assert.include(output, displayName);
     assert.include(output, entityTypeId);
   });
 
   it('should Create a Session Entity Type', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} create-session-entity-type -s ${sessionId} -e ${synonym1} -e ${synonym2} -d ${displayName} -o ENTITY_OVERRIDE_MODE_OVERRIDE`
     );
     assert.include(output, sessionId);
@@ -159,7 +159,7 @@ describe('resources', () => {
   });
 
   it('should List the Session Entity Type', async () => {
-    const output = await exec(
+    const output = exec(
       `${cmd} list-session-entity-types -s ${sessionId}`
     );
     assert.include(output, sessionId);
@@ -168,24 +168,24 @@ describe('resources', () => {
   });
 
   it('should Delete the Session Entity Type', async () => {
-    let output = await exec(
+    let output = exec(
       `${cmd} delete-session-entity-type -s ${sessionId} -d ${displayName}`
     );
     assert.include(output, displayName);
 
     // Verify the Session Entity Type is Deleted
-    output = await exec(`${cmd} list-session-entity-types -s ${sessionId}`);
+    output = exec(`${cmd} list-session-entity-types -s ${sessionId}`);
     assert.notInclude(output, sessionId);
     assert.notInclude(output, displayName);
     assert.notInclude(output, '2');
   });
 
   it('should Delete the Entity Type', async () => {
-    let output = await exec(`${cmd} delete-entity-type -e ${entityTypeId}`);
+    let output = exec(`${cmd} delete-entity-type -e ${entityTypeId}`);
     assert.include(output, entityTypeId);
 
     // Verify the Entity Type is Deleted
-    output = await exec(`${cmd} list-entity-types`);
+    output = exec(`${cmd} list-entity-types`);
     assert.notInclude(output, displayName);
     assert.notInclude(output, entityTypeId);
   });

--- a/samples/system-test/resource.test.js
+++ b/samples/system-test/resource.test.js
@@ -15,13 +15,10 @@
 
 'use strict';
 
-const path = require('path');
 const {assert} = require('chai');
-const cp = require('child_process');
+const execSync = require('child_process').execSync;
 const uuid = require('uuid');
-
-const cwd = path.join(__dirname, '..');
-const exec = async cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const exec = cmd => execSync(cmd, {encoding: 'utf8'});
 
 describe('resources', () => {
   const cmd = 'node resource.js';

--- a/samples/system-test/resource.test.js
+++ b/samples/system-test/resource.test.js
@@ -17,13 +17,18 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const execa = require('execa');
+const cp = require('child_process');
 const uuid = require('uuid');
 
 const cwd = path.join(__dirname, '..');
 const exec = async cmd => {
-  const {stdout} = await execa.shell(cmd, {cwd});
-  return stdout;
+  cp.cwd = cwd;
+  try {
+    const res = cp.execSync(cmd, {stdio: 'pipe'});
+    return res.toString('utf-8');
+  } catch (err) {
+    throw new Error(err.message);
+  }
 };
 
 describe('resources', () => {


### PR DESCRIPTION
Fixes #354  (it's a good idea to open an issue first for discussion)

- [x] Tests and linter pass
- [? How can I check this?] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
