### PR TITLE
feat: add methods for SetAgent and DeleteAgent

### DIFF
--- a/protos/google/cloud/dialogflow/v2/agent.proto
+++ b/protos/google/cloud/dialogflow/v2/agent.proto
@@ -22,6 +22,7 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
+import "google/api/client.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Dialogflow.V2";
@@ -44,7 +45,7 @@ option objc_class_prefix = "DF";
 // You can create an agent using both Dialogflow Standard Edition and
 // Dialogflow Enterprise Edition. For details, see
 // [Dialogflow
-// Editions](https://cloud.google.com/dialogflow-enterprise/docs/editions).
+// Editions](https://cloud.google.com/dialogflow/docs/editions).
 //
 // You can save your agent for backup or versioning by exporting the agent by
 // using the [ExportAgent][google.cloud.dialogflow.v2.Agents.ExportAgent] method. You can import a saved
@@ -52,18 +53,38 @@ option objc_class_prefix = "DF";
 //
 // Dialogflow provides several
 // [prebuilt
-// agents](https://cloud.google.com/dialogflow-enterprise/docs/agents-prebuilt)
+// agents](https://cloud.google.com/dialogflow/docs/agents-prebuilt)
 // for common conversation scenarios such as determining a date and time,
 // converting currency, and so on.
 //
 // For more information about agents, see the
 // [Dialogflow
-// documentation](https://cloud.google.com/dialogflow-enterprise/docs/agents-overview).
+// documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
 service Agents {
+  option (google.api.default_host) = "dialogflow.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform,"
+      "https://www.googleapis.com/auth/dialogflow";
+
   // Retrieves the specified agent.
   rpc GetAgent(GetAgentRequest) returns (Agent) {
     option (google.api.http) = {
       get: "/v2/{parent=projects/*}/agent"
+    };
+  }
+
+  // Creates/updates the specified agent.
+  rpc SetAgent(SetAgentRequest) returns (Agent) {
+    option (google.api.http) = {
+      post: "/v2/{agent.parent=projects/*}/agent"
+      body: "agent"
+    };
+  }
+
+  // Deletes the specified agent.
+  rpc DeleteAgent(DeleteAgentRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v2/{parent=projects/*}/agent"
     };
   }
 
@@ -144,6 +165,36 @@ message Agent {
     MATCH_MODE_ML_ONLY = 2;
   }
 
+  // API version for the agent.
+  enum ApiVersion {
+    // Not specified.
+    API_VERSION_UNSPECIFIED = 0;
+
+    // Legacy V1 API.
+    API_VERSION_V1 = 1;
+
+    // V2 API.
+    API_VERSION_V2 = 2;
+
+    // V2beta1 API.
+    API_VERSION_V2_BETA_1 = 3;
+  }
+
+  // Represents the agent tier.
+  enum Tier {
+    // Not specified. This value should never be used.
+    TIER_UNSPECIFIED = 0;
+
+    // Standard tier.
+    TIER_STANDARD = 1;
+
+    // Enterprise tier (Essentials).
+    TIER_ENTERPRISE = 2;
+
+    // Enterprise tier (Plus).
+    TIER_ENTERPRISE_PLUS = 3;
+  }
+
   // Required. The project of this agent.
   // Format: `projects/<Project ID>`.
   string parent = 1;
@@ -153,7 +204,7 @@ message Agent {
 
   // Required. The default language of the agent as a language tag. See
   // [Language
-  // Support](https://cloud.google.com/dialogflow-enterprise/docs/reference/language)
+  // Support](https://cloud.google.com/dialogflow/docs/reference/language)
   // for a list of the currently supported language codes. This field cannot be
   // set by the `Update` method.
   string default_language_code = 3;
@@ -174,7 +225,7 @@ message Agent {
   // Optional. The URI of the agent's avatar.
   // Avatars are used throughout the Dialogflow console and in the self-hosted
   // [Web
-  // Demo](https://cloud.google.com/dialogflow-enterprise/docs/integrations/web-demo)
+  // Demo](https://cloud.google.com/dialogflow/docs/integrations/web-demo)
   // integration.
   string avatar_uri = 7;
 
@@ -192,11 +243,36 @@ message Agent {
   // values range from 0.0 (completely uncertain) to 1.0 (completely certain).
   // If set to 0.0, the default of 0.3 is used.
   float classification_threshold = 10;
+
+  // Optional. API version displayed in Dialogflow console. If not specified,
+  // V2 API is assumed. Clients are free to query different service endpoints
+  // for different API versions. However, bots connectors and webhook calls will
+  // follow the specified API version.
+  ApiVersion api_version = 14;
+
+  // Optional. The agent tier. If not specified, TIER_STANDARD is assumed.
+  Tier tier = 15;
 }
 
 // The request message for [Agents.GetAgent][google.cloud.dialogflow.v2.Agents.GetAgent].
 message GetAgentRequest {
   // Required. The project that the agent to fetch is associated with.
+  // Format: `projects/<Project ID>`.
+  string parent = 1;
+}
+
+// The request message for [Agents.SetAgent][google.cloud.dialogflow.v2.Agents.SetAgent].
+message SetAgentRequest {
+  // Required. The agent to update.
+  Agent agent = 1;
+
+  // Optional. The mask to control which fields get updated.
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// The request message for [Agents.DeleteAgent][google.cloud.dialogflow.v2.Agents.DeleteAgent].
+message DeleteAgentRequest {
+  // Required. The project that the agent to delete is associated with.
   // Format: `projects/<Project ID>`.
   string parent = 1;
 }

--- a/src/v2/agents_client.js
+++ b/src/v2/agents_client.js
@@ -226,6 +226,8 @@ class AgentsClient {
       'exportAgent',
       'importAgent',
       'restoreAgent',
+      'setAgent',
+      'deleteAgent',
     ];
     for (const methodName of agentsStubMethods) {
       this._innerApiCalls[methodName] = gax.createApiCall(
@@ -958,6 +960,40 @@ class AgentsClient {
     });
 
     return this._innerApiCalls.restoreAgent(request, options, callback);
+  }
+
+  setAgent(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      parent: request.parent,
+    });
+
+    return this._innerApiCalls.setAgent(request, options, callback);
+  }
+
+  deleteAgent(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      parent: request.parent,
+    });
+
+    return this._innerApiCalls.deleteAgent(request, options, callback);
   }
 
   // --------------------

--- a/src/v2/agents_client_config.json
+++ b/src/v2/agents_client_config.json
@@ -49,6 +49,16 @@
           "timeout_millis": 60000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "SetAgent": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteAgent": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }


### PR DESCRIPTION
Fixes #413

This PR pulls in the updates to `agent.proto` from here https://github.com/googleapis/googleapis/blob/master/google/cloud/dialogflow/v2/agent.proto

and adds stub methods for `SetAgent` and `DeleteAgent`.

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)