### PR TITLE
feat: deferred client initialization

### DIFF
--- a/src/v2/agents_client.ts
+++ b/src/v2/agents_client.ts
@@ -41,8 +41,8 @@ const version = require('../../../package.json').version;
  *  in your app, product, or service to determine user intent and respond to the
  *  user in a natural way.
  *
- *  After you create an agent, you can add [Intents][google.cloud.dialogflow.v2.Intents], [Contexts][google.cloud.dialogflow.v2.Contexts],
- *  [Entity Types][google.cloud.dialogflow.v2.EntityTypes], [Webhooks][google.cloud.dialogflow.v2.WebhookRequest], and so on to
+ *  After you create an agent, you can add {@link google.cloud.dialogflow.v2.Intents|Intents}, {@link google.cloud.dialogflow.v2.Contexts|Contexts},
+ *  {@link google.cloud.dialogflow.v2.EntityTypes|Entity Types}, {@link google.cloud.dialogflow.v2.WebhookRequest|Webhooks}, and so on to
  *  manage the flow of a conversation and match user input to predefined intents
  *  and actions.
  *
@@ -52,8 +52,8 @@ const version = require('../../../package.json').version;
  *  Editions](https://cloud.google.com/dialogflow/docs/editions).
  *
  *  You can save your agent for backup or versioning by exporting the agent by
- *  using the [ExportAgent][google.cloud.dialogflow.v2.Agents.ExportAgent] method. You can import a saved
- *  agent by using the [ImportAgent][google.cloud.dialogflow.v2.Agents.ImportAgent] method.
+ *  using the {@link google.cloud.dialogflow.v2.Agents.ExportAgent|ExportAgent} method. You can import a saved
+ *  agent by using the {@link google.cloud.dialogflow.v2.Agents.ImportAgent|ImportAgent} method.
  *
  *  Dialogflow provides several
  *  [prebuilt
@@ -72,9 +72,14 @@ export class AgentsClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  agentsStub: Promise<{[name: string]: Function}>;
+  agentsStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of AgentsClient.
@@ -98,8 +103,6 @@ export class AgentsClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -129,25 +132,28 @@ export class AgentsClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof AgentsClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -163,7 +169,7 @@ export class AgentsClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -171,18 +177,22 @@ export class AgentsClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      agentPathTemplate: new gaxModule.PathTemplate('projects/{project}/agent'),
-      contextPathTemplate: new gaxModule.PathTemplate(
+      agentPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/agent'
+      ),
+      contextPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}/contexts/{context}'
       ),
-      entityTypePathTemplate: new gaxModule.PathTemplate(
+      entityTypePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/entityTypes/{entity_type}'
       ),
-      intentPathTemplate: new gaxModule.PathTemplate(
+      intentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      projectPathTemplate: new gaxModule.PathTemplate('projects/{project}'),
-      sessionEntityTypePathTemplate: new gaxModule.PathTemplate(
+      projectPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}'
+      ),
+      sessionEntityTypePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}/entityTypes/{entity_type}'
       ),
     };
@@ -191,7 +201,7 @@ export class AgentsClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      searchAgents: new gaxModule.PageDescriptor(
+      searchAgents: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'agents'
@@ -202,13 +212,15 @@ export class AgentsClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const trainAgentResponse = protoFilesRoot.lookup(
@@ -237,22 +249,22 @@ export class AgentsClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      trainAgent: new gaxModule.LongrunningDescriptor(
+      trainAgent: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         trainAgentResponse.decode.bind(trainAgentResponse),
         trainAgentMetadata.decode.bind(trainAgentMetadata)
       ),
-      exportAgent: new gaxModule.LongrunningDescriptor(
+      exportAgent: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         exportAgentResponse.decode.bind(exportAgentResponse),
         exportAgentMetadata.decode.bind(exportAgentMetadata)
       ),
-      importAgent: new gaxModule.LongrunningDescriptor(
+      importAgent: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         importAgentResponse.decode.bind(importAgentResponse),
         importAgentMetadata.decode.bind(importAgentMetadata)
       ),
-      restoreAgent: new gaxModule.LongrunningDescriptor(
+      restoreAgent: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         restoreAgentResponse.decode.bind(restoreAgentResponse),
         restoreAgentMetadata.decode.bind(restoreAgentMetadata)
@@ -260,7 +272,7 @@ export class AgentsClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2.Agents',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -271,17 +283,35 @@ export class AgentsClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.agentsStub) {
+      return this.agentsStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2.Agents.
-    this.agentsStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.agentsStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2.Agents'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2.Agents,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2.Agents,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -311,9 +341,9 @@ export class AgentsClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -327,6 +357,8 @@ export class AgentsClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.agentsStub;
   }
 
   /**
@@ -452,6 +484,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.getAgent(request, options, callback);
   }
   setAgent(
@@ -525,6 +558,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       'agent.parent': request.agent!.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.setAgent(request, options, callback);
   }
   deleteAgent(
@@ -598,6 +632,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteAgent(request, options, callback);
   }
   getValidationResult(
@@ -686,6 +721,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.getValidationResult(request, options, callback);
   }
 
@@ -717,7 +753,7 @@ export class AgentsClient {
   /**
    * Trains the specified agent.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -776,6 +812,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.trainAgent(request, options, callback);
   }
   exportAgent(
@@ -806,7 +843,7 @@ export class AgentsClient {
   /**
    * Exports the specified agent to a ZIP file.
    *
-   * Operation <response: [ExportAgentResponse][google.cloud.dialogflow.v2.ExportAgentResponse]>
+   * Operation <response: {@link google.cloud.dialogflow.v2.ExportAgentResponse|ExportAgentResponse}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -870,6 +907,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.exportAgent(request, options, callback);
   }
   importAgent(
@@ -904,7 +942,7 @@ export class AgentsClient {
    * Intents and entity types with the same name are replaced with the new
    * versions from ImportAgentRequest.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -968,6 +1006,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.importAgent(request, options, callback);
   }
   restoreAgent(
@@ -1001,7 +1040,7 @@ export class AgentsClient {
    * Replaces the current agent version with a new one. All the intents and
    * entity types in the older version are deleted.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1065,6 +1104,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.restoreAgent(request, options, callback);
   }
   searchAgents(
@@ -1160,6 +1200,7 @@ export class AgentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.searchAgents(request, options, callback);
   }
 
@@ -1205,6 +1246,7 @@ export class AgentsClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.searchAgents.createStream(
       this._innerApiCalls.searchAgents as gax.GaxCall,
       request,
@@ -1445,8 +1487,9 @@ export class AgentsClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.agentsStub.then(stub => {
+      return this.agentsStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2/contexts_client.ts
+++ b/src/v2/contexts_client.ts
@@ -43,8 +43,8 @@ const version = require('../../../package.json').version;
  *  geographic location, and so on.
  *
  *  You can include contexts as input parameters of a
- *  [DetectIntent][google.cloud.dialogflow.v2.Sessions.DetectIntent] (or
- *  [StreamingDetectIntent][google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent]) request,
+ *  {@link google.cloud.dialogflow.v2.Sessions.DetectIntent|DetectIntent} (or
+ *  {@link google.cloud.dialogflow.v2.Sessions.StreamingDetectIntent|StreamingDetectIntent}) request,
  *  or as output contexts included in the returned intent.
  *  Contexts expire when an intent is matched, after the number of `DetectIntent`
  *  requests specified by the `lifespan_count` parameter, or after 20 minutes
@@ -61,8 +61,13 @@ export class ContextsClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  contextsStub: Promise<{[name: string]: Function}>;
+  contextsStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of ContextsClient.
@@ -86,8 +91,6 @@ export class ContextsClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -117,25 +120,28 @@ export class ContextsClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof ContextsClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -151,7 +157,7 @@ export class ContextsClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -159,17 +165,19 @@ export class ContextsClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      agentPathTemplate: new gaxModule.PathTemplate('projects/{project}/agent'),
-      contextPathTemplate: new gaxModule.PathTemplate(
+      agentPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/agent'
+      ),
+      contextPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}/contexts/{context}'
       ),
-      entityTypePathTemplate: new gaxModule.PathTemplate(
+      entityTypePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/entityTypes/{entity_type}'
       ),
-      intentPathTemplate: new gaxModule.PathTemplate(
+      intentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      sessionEntityTypePathTemplate: new gaxModule.PathTemplate(
+      sessionEntityTypePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}/entityTypes/{entity_type}'
       ),
     };
@@ -178,7 +186,7 @@ export class ContextsClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listContexts: new gaxModule.PageDescriptor(
+      listContexts: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'contexts'
@@ -186,7 +194,7 @@ export class ContextsClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2.Contexts',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -197,17 +205,35 @@ export class ContextsClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.contextsStub) {
+      return this.contextsStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2.Contexts.
-    this.contextsStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.contextsStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2.Contexts'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2.Contexts,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2.Contexts,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -234,9 +260,9 @@ export class ContextsClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -250,6 +276,8 @@ export class ContextsClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.contextsStub;
   }
 
   /**
@@ -375,6 +403,7 @@ export class ContextsClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getContext(request, options, callback);
   }
   createContext(
@@ -452,6 +481,7 @@ export class ContextsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createContext(request, options, callback);
   }
   updateContext(
@@ -526,6 +556,7 @@ export class ContextsClient {
     ] = gax.routingHeader.fromParams({
       'context.name': request.context!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateContext(request, options, callback);
   }
   deleteContext(
@@ -599,6 +630,7 @@ export class ContextsClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteContext(request, options, callback);
   }
   deleteAllContexts(
@@ -680,6 +712,7 @@ export class ContextsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteAllContexts(request, options, callback);
   }
 
@@ -770,6 +803,7 @@ export class ContextsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listContexts(request, options, callback);
   }
 
@@ -815,6 +849,7 @@ export class ContextsClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listContexts.createStream(
       this._innerApiCalls.listContexts as gax.GaxCall,
       request,
@@ -1032,8 +1067,9 @@ export class ContextsClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.contextsStub.then(stub => {
+      return this.contextsStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2/entity_types_client.ts
+++ b/src/v2/entity_types_client.ts
@@ -59,7 +59,7 @@ const version = require('../../../package.json').version;
  *
  *  *   **User** - entities that are built for an individual user such as
  *      favorites, preferences, playlists, and so on. A user entity is
- *      represented by the [SessionEntityType][google.cloud.dialogflow.v2.SessionEntityType] type.
+ *      represented by the {@link google.cloud.dialogflow.v2.SessionEntityType|SessionEntityType} type.
  *
  *  For more information about entity types, see the
  *  [Dialogflow
@@ -72,9 +72,14 @@ export class EntityTypesClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  entityTypesStub: Promise<{[name: string]: Function}>;
+  entityTypesStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of EntityTypesClient.
@@ -98,8 +103,6 @@ export class EntityTypesClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -129,25 +132,28 @@ export class EntityTypesClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof EntityTypesClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -163,7 +169,7 @@ export class EntityTypesClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -171,17 +177,19 @@ export class EntityTypesClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      agentPathTemplate: new gaxModule.PathTemplate('projects/{project}/agent'),
-      contextPathTemplate: new gaxModule.PathTemplate(
+      agentPathTemplate: new this._gaxModule.PathTemplate(
+        'projects/{project}/agent'
+      ),
+      contextPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}/contexts/{context}'
       ),
-      entityTypePathTemplate: new gaxModule.PathTemplate(
+      entityTypePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/entityTypes/{entity_type}'
       ),
-      intentPathTemplate: new gaxModule.PathTemplate(
+      intentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      sessionEntityTypePathTemplate: new gaxModule.PathTemplate(
+      sessionEntityTypePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}/entityTypes/{entity_type}'
       ),
     };
@@ -190,7 +198,7 @@ export class EntityTypesClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listEntityTypes: new gaxModule.PageDescriptor(
+      listEntityTypes: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'entityTypes'
@@ -201,13 +209,15 @@ export class EntityTypesClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const batchUpdateEntityTypesResponse = protoFilesRoot.lookup(
@@ -242,7 +252,7 @@ export class EntityTypesClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      batchUpdateEntityTypes: new gaxModule.LongrunningDescriptor(
+      batchUpdateEntityTypes: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         batchUpdateEntityTypesResponse.decode.bind(
           batchUpdateEntityTypesResponse
@@ -251,7 +261,7 @@ export class EntityTypesClient {
           batchUpdateEntityTypesMetadata
         )
       ),
-      batchDeleteEntityTypes: new gaxModule.LongrunningDescriptor(
+      batchDeleteEntityTypes: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         batchDeleteEntityTypesResponse.decode.bind(
           batchDeleteEntityTypesResponse
@@ -260,17 +270,17 @@ export class EntityTypesClient {
           batchDeleteEntityTypesMetadata
         )
       ),
-      batchCreateEntities: new gaxModule.LongrunningDescriptor(
+      batchCreateEntities: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         batchCreateEntitiesResponse.decode.bind(batchCreateEntitiesResponse),
         batchCreateEntitiesMetadata.decode.bind(batchCreateEntitiesMetadata)
       ),
-      batchUpdateEntities: new gaxModule.LongrunningDescriptor(
+      batchUpdateEntities: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         batchUpdateEntitiesResponse.decode.bind(batchUpdateEntitiesResponse),
         batchUpdateEntitiesMetadata.decode.bind(batchUpdateEntitiesMetadata)
       ),
-      batchDeleteEntities: new gaxModule.LongrunningDescriptor(
+      batchDeleteEntities: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         batchDeleteEntitiesResponse.decode.bind(batchDeleteEntitiesResponse),
         batchDeleteEntitiesMetadata.decode.bind(batchDeleteEntitiesMetadata)
@@ -278,7 +288,7 @@ export class EntityTypesClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2.EntityTypes',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -289,17 +299,35 @@ export class EntityTypesClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.entityTypesStub) {
+      return this.entityTypesStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2.EntityTypes.
-    this.entityTypesStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.entityTypesStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2.EntityTypes'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2.EntityTypes,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2.EntityTypes,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -330,9 +358,9 @@ export class EntityTypesClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -346,6 +374,8 @@ export class EntityTypesClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.entityTypesStub;
   }
 
   /**
@@ -479,6 +509,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getEntityType(request, options, callback);
   }
   createEntityType(
@@ -569,6 +600,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createEntityType(request, options, callback);
   }
   updateEntityType(
@@ -658,6 +690,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       'entity_type.name': request.entityType!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateEntityType(request, options, callback);
   }
   deleteEntityType(
@@ -739,6 +772,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteEntityType(request, options, callback);
   }
 
@@ -770,7 +804,7 @@ export class EntityTypesClient {
   /**
    * Updates/Creates multiple entity types in the specified agent.
    *
-   * Operation <response: [BatchUpdateEntityTypesResponse][google.cloud.dialogflow.v2.BatchUpdateEntityTypesResponse]>
+   * Operation <response: {@link google.cloud.dialogflow.v2.BatchUpdateEntityTypesResponse|BatchUpdateEntityTypesResponse}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -845,6 +879,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchUpdateEntityTypes(
       request,
       options,
@@ -879,7 +914,7 @@ export class EntityTypesClient {
   /**
    * Deletes entity types in the specified agent.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -941,6 +976,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchDeleteEntityTypes(
       request,
       options,
@@ -975,7 +1011,7 @@ export class EntityTypesClient {
   /**
    * Creates multiple new entities in the specified entity type.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1043,6 +1079,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchCreateEntities(request, options, callback);
   }
   batchUpdateEntities(
@@ -1076,7 +1113,7 @@ export class EntityTypesClient {
    * specified in the request.
    *
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1146,6 +1183,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchUpdateEntities(request, options, callback);
   }
   batchDeleteEntities(
@@ -1177,7 +1215,7 @@ export class EntityTypesClient {
    * Deletes entities in the specified entity type.
    *
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1247,6 +1285,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchDeleteEntities(request, options, callback);
   }
   listEntityTypes(
@@ -1343,6 +1382,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listEntityTypes(request, options, callback);
   }
 
@@ -1395,6 +1435,7 @@ export class EntityTypesClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listEntityTypes.createStream(
       this._innerApiCalls.listEntityTypes as gax.GaxCall,
       request,
@@ -1612,8 +1653,9 @@ export class EntityTypesClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.entityTypesStub.then(stub => {
+      return this.entityTypesStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2beta1/entity_types_client.ts
+++ b/src/v2beta1/entity_types_client.ts
@@ -58,7 +58,7 @@ const version = require('../../../package.json').version;
  *
  *  *   **User** - entities that are built for an individual user such as
  *      favorites, preferences, playlists, and so on. A user entity is
- *      represented by the [SessionEntityType][google.cloud.dialogflow.v2beta1.SessionEntityType] type.
+ *      represented by the {@link google.cloud.dialogflow.v2beta1.SessionEntityType|SessionEntityType} type.
  *
  *  For more information about entity types, see the
  *  [Dialogflow
@@ -71,8 +71,13 @@ export class EntityTypesClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  entityTypesStub: Promise<{[name: string]: Function}>;
+  entityTypesStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of EntityTypesClient.
@@ -96,8 +101,6 @@ export class EntityTypesClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -127,25 +130,28 @@ export class EntityTypesClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof EntityTypesClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -161,7 +167,7 @@ export class EntityTypesClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -169,16 +175,16 @@ export class EntityTypesClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gaxModule.PathTemplate(
+      projectPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent'
       ),
-      projectIntentPathTemplate: new gaxModule.PathTemplate(
+      projectIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      projectLocationPathTemplate: new gaxModule.PathTemplate(
+      projectLocationPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent'
       ),
-      projectLocationIntentPathTemplate: new gaxModule.PathTemplate(
+      projectLocationIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent/intents/{intent}'
       ),
     };
@@ -187,7 +193,7 @@ export class EntityTypesClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listEntityTypes: new gaxModule.PageDescriptor(
+      listEntityTypes: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'entityTypes'
@@ -195,7 +201,7 @@ export class EntityTypesClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2beta1.EntityTypes',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -206,17 +212,35 @@ export class EntityTypesClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.entityTypesStub) {
+      return this.entityTypesStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2beta1.EntityTypes.
-    this.entityTypesStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.entityTypesStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2beta1.EntityTypes'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2beta1.EntityTypes,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2beta1.EntityTypes,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -247,9 +271,9 @@ export class EntityTypesClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -263,6 +287,8 @@ export class EntityTypesClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.entityTypesStub;
   }
 
   /**
@@ -404,6 +430,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getEntityType(request, options, callback);
   }
   createEntityType(
@@ -494,6 +521,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createEntityType(request, options, callback);
   }
   updateEntityType(
@@ -583,6 +611,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       'entity_type.name': request.entityType!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateEntityType(request, options, callback);
   }
   deleteEntityType(
@@ -664,6 +693,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteEntityType(request, options, callback);
   }
   batchUpdateEntityTypes(
@@ -692,7 +722,7 @@ export class EntityTypesClient {
   /**
    * Updates/Creates multiple entity types in the specified agent.
    *
-   * Operation <response: [BatchUpdateEntityTypesResponse][google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesResponse]>
+   * Operation <response: {@link google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesResponse|BatchUpdateEntityTypesResponse}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -763,6 +793,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchUpdateEntityTypes(
       request,
       options,
@@ -795,7 +826,7 @@ export class EntityTypesClient {
   /**
    * Deletes entity types in the specified agent.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -853,6 +884,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchDeleteEntityTypes(
       request,
       options,
@@ -885,7 +917,7 @@ export class EntityTypesClient {
   /**
    * Creates multiple new entities in the specified entity type.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -949,6 +981,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchCreateEntities(request, options, callback);
   }
   batchUpdateEntities(
@@ -979,7 +1012,7 @@ export class EntityTypesClient {
    * method does not affect entities in the entity type that aren't explicitly
    * specified in the request.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1045,6 +1078,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchUpdateEntities(request, options, callback);
   }
   batchDeleteEntities(
@@ -1073,7 +1107,7 @@ export class EntityTypesClient {
   /**
    * Deletes entities in the specified entity type.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1139,6 +1173,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchDeleteEntities(request, options, callback);
   }
 
@@ -1236,6 +1271,7 @@ export class EntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listEntityTypes(request, options, callback);
   }
 
@@ -1288,6 +1324,7 @@ export class EntityTypesClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listEntityTypes.createStream(
       this._innerApiCalls.listEntityTypes as gax.GaxCall,
       request,
@@ -1464,8 +1501,9 @@ export class EntityTypesClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.entityTypesStub.then(stub => {
+      return this.entityTypesStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2beta1/intents_client.ts
+++ b/src/v2beta1/intents_client.ts
@@ -37,8 +37,8 @@ const version = require('../../../package.json').version;
 /**
  *  An intent represents a mapping between input from a user and an action to
  *  be taken by your application. When you pass user input to the
- *  [DetectIntent][google.cloud.dialogflow.v2beta1.Sessions.DetectIntent] (or
- *  [StreamingDetectIntent][google.cloud.dialogflow.v2beta1.Sessions.StreamingDetectIntent]) method, the
+ *  {@link google.cloud.dialogflow.v2beta1.Sessions.DetectIntent|DetectIntent} (or
+ *  {@link google.cloud.dialogflow.v2beta1.Sessions.StreamingDetectIntent|StreamingDetectIntent}) method, the
  *  Dialogflow API analyzes the input and searches
  *  for a matching intent. If no match is found, the Dialogflow API returns a
  *  fallback intent (`is_fallback` = true).
@@ -75,8 +75,13 @@ export class IntentsClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  intentsStub: Promise<{[name: string]: Function}>;
+  intentsStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of IntentsClient.
@@ -100,8 +105,6 @@ export class IntentsClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -131,25 +134,28 @@ export class IntentsClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof IntentsClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -165,7 +171,7 @@ export class IntentsClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -173,16 +179,16 @@ export class IntentsClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gaxModule.PathTemplate(
+      projectPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent'
       ),
-      projectIntentPathTemplate: new gaxModule.PathTemplate(
+      projectIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      projectLocationPathTemplate: new gaxModule.PathTemplate(
+      projectLocationPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent'
       ),
-      projectLocationIntentPathTemplate: new gaxModule.PathTemplate(
+      projectLocationIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent/intents/{intent}'
       ),
     };
@@ -191,7 +197,7 @@ export class IntentsClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listIntents: new gaxModule.PageDescriptor(
+      listIntents: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'intents'
@@ -199,7 +205,7 @@ export class IntentsClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2beta1.Intents',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -210,17 +216,35 @@ export class IntentsClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.intentsStub) {
+      return this.intentsStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2beta1.Intents.
-    this.intentsStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.intentsStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2beta1.Intents'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2beta1.Intents,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2beta1.Intents,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -248,9 +272,9 @@ export class IntentsClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -264,6 +288,8 @@ export class IntentsClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.intentsStub;
   }
 
   /**
@@ -399,6 +425,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getIntent(request, options, callback);
   }
   createIntent(
@@ -491,6 +518,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createIntent(request, options, callback);
   }
   updateIntent(
@@ -582,6 +610,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       'intent.name': request.intent!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateIntent(request, options, callback);
   }
   deleteIntent(
@@ -665,6 +694,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteIntent(request, options, callback);
   }
   batchUpdateIntents(
@@ -693,7 +723,7 @@ export class IntentsClient {
   /**
    * Updates/Creates multiple intents in the specified agent.
    *
-   * Operation <response: [BatchUpdateIntentsResponse][google.cloud.dialogflow.v2beta1.BatchUpdateIntentsResponse]>
+   * Operation <response: {@link google.cloud.dialogflow.v2beta1.BatchUpdateIntentsResponse|BatchUpdateIntentsResponse}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -765,6 +795,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchUpdateIntents(request, options, callback);
   }
   batchDeleteIntents(
@@ -793,7 +824,7 @@ export class IntentsClient {
   /**
    * Deletes intents in the specified agent.
    *
-   * Operation <response: [google.protobuf.Empty][google.protobuf.Empty]>
+   * Operation <response: {@link google.protobuf.Empty|google.protobuf.Empty}>
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -851,6 +882,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchDeleteIntents(request, options, callback);
   }
 
@@ -950,6 +982,7 @@ export class IntentsClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listIntents(request, options, callback);
   }
 
@@ -1004,6 +1037,7 @@ export class IntentsClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listIntents.createStream(
       this._innerApiCalls.listIntents as gax.GaxCall,
       request,
@@ -1180,8 +1214,9 @@ export class IntentsClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.intentsStub.then(stub => {
+      return this.intentsStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2beta1/knowledge_bases_client.ts
+++ b/src/v2beta1/knowledge_bases_client.ts
@@ -46,8 +46,13 @@ export class KnowledgeBasesClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  knowledgeBasesStub: Promise<{[name: string]: Function}>;
+  knowledgeBasesStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of KnowledgeBasesClient.
@@ -71,8 +76,6 @@ export class KnowledgeBasesClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -102,25 +105,28 @@ export class KnowledgeBasesClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof KnowledgeBasesClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -136,7 +142,7 @@ export class KnowledgeBasesClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -144,16 +150,16 @@ export class KnowledgeBasesClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gaxModule.PathTemplate(
+      projectPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent'
       ),
-      projectIntentPathTemplate: new gaxModule.PathTemplate(
+      projectIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      projectLocationPathTemplate: new gaxModule.PathTemplate(
+      projectLocationPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent'
       ),
-      projectLocationIntentPathTemplate: new gaxModule.PathTemplate(
+      projectLocationIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent/intents/{intent}'
       ),
     };
@@ -162,7 +168,7 @@ export class KnowledgeBasesClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listKnowledgeBases: new gaxModule.PageDescriptor(
+      listKnowledgeBases: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'knowledgeBases'
@@ -170,7 +176,7 @@ export class KnowledgeBasesClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2beta1.KnowledgeBases',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -181,17 +187,35 @@ export class KnowledgeBasesClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.knowledgeBasesStub) {
+      return this.knowledgeBasesStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2beta1.KnowledgeBases.
-    this.knowledgeBasesStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.knowledgeBasesStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2beta1.KnowledgeBases'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2beta1.KnowledgeBases,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2beta1.KnowledgeBases,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -217,9 +241,9 @@ export class KnowledgeBasesClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -233,6 +257,8 @@ export class KnowledgeBasesClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.knowledgeBasesStub;
   }
 
   /**
@@ -370,6 +396,7 @@ export class KnowledgeBasesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getKnowledgeBase(request, options, callback);
   }
   createKnowledgeBase(
@@ -456,6 +483,7 @@ export class KnowledgeBasesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createKnowledgeBase(request, options, callback);
   }
   deleteKnowledgeBase(
@@ -543,6 +571,7 @@ export class KnowledgeBasesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteKnowledgeBase(request, options, callback);
   }
   updateKnowledgeBase(
@@ -630,6 +659,7 @@ export class KnowledgeBasesClient {
     ] = gax.routingHeader.fromParams({
       'knowledge_base.name': request.knowledgeBase!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateKnowledgeBase(request, options, callback);
   }
 
@@ -723,6 +753,7 @@ export class KnowledgeBasesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listKnowledgeBases(request, options, callback);
   }
 
@@ -768,6 +799,7 @@ export class KnowledgeBasesClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listKnowledgeBases.createStream(
       this._innerApiCalls.listKnowledgeBases as gax.GaxCall,
       request,
@@ -944,8 +976,9 @@ export class KnowledgeBasesClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.knowledgeBasesStub.then(stub => {
+      return this.knowledgeBasesStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2beta1/session_entity_types_client.ts
+++ b/src/v2beta1/session_entity_types_client.ts
@@ -60,8 +60,13 @@ export class SessionEntityTypesClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  sessionEntityTypesStub: Promise<{[name: string]: Function}>;
+  sessionEntityTypesStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of SessionEntityTypesClient.
@@ -85,8 +90,6 @@ export class SessionEntityTypesClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -116,25 +119,28 @@ export class SessionEntityTypesClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof SessionEntityTypesClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -150,7 +156,7 @@ export class SessionEntityTypesClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -158,16 +164,16 @@ export class SessionEntityTypesClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gaxModule.PathTemplate(
+      projectPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent'
       ),
-      projectIntentPathTemplate: new gaxModule.PathTemplate(
+      projectIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      projectLocationPathTemplate: new gaxModule.PathTemplate(
+      projectLocationPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent'
       ),
-      projectLocationIntentPathTemplate: new gaxModule.PathTemplate(
+      projectLocationIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent/intents/{intent}'
       ),
     };
@@ -176,7 +182,7 @@ export class SessionEntityTypesClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listSessionEntityTypes: new gaxModule.PageDescriptor(
+      listSessionEntityTypes: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'sessionEntityTypes'
@@ -184,7 +190,7 @@ export class SessionEntityTypesClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2beta1.SessionEntityTypes',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -195,17 +201,36 @@ export class SessionEntityTypesClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.sessionEntityTypesStub) {
+      return this.sessionEntityTypesStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2beta1.SessionEntityTypes.
-    this.sessionEntityTypesStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.sessionEntityTypesStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2beta1.SessionEntityTypes'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2beta1.SessionEntityTypes,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2beta1
+            .SessionEntityTypes,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -231,9 +256,9 @@ export class SessionEntityTypesClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -247,6 +272,8 @@ export class SessionEntityTypesClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.sessionEntityTypesStub;
   }
 
   /**
@@ -389,6 +416,7 @@ export class SessionEntityTypesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getSessionEntityType(request, options, callback);
   }
   createSessionEntityType(
@@ -483,6 +511,7 @@ export class SessionEntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createSessionEntityType(
       request,
       options,
@@ -578,6 +607,7 @@ export class SessionEntityTypesClient {
     ] = gax.routingHeader.fromParams({
       'session_entity_type.name': request.sessionEntityType!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateSessionEntityType(
       request,
       options,
@@ -671,6 +701,7 @@ export class SessionEntityTypesClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteSessionEntityType(
       request,
       options,
@@ -773,6 +804,7 @@ export class SessionEntityTypesClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listSessionEntityTypes(
       request,
       options,
@@ -826,6 +858,7 @@ export class SessionEntityTypesClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listSessionEntityTypes.createStream(
       this._innerApiCalls.listSessionEntityTypes as gax.GaxCall,
       request,
@@ -1002,8 +1035,9 @@ export class SessionEntityTypesClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.sessionEntityTypesStub.then(stub => {
+      return this.sessionEntityTypesStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/src/v2beta1/sessions_client.ts
+++ b/src/v2beta1/sessions_client.ts
@@ -33,8 +33,8 @@ const version = require('../../../package.json').version;
 
 /**
  *  A session represents an interaction with a user. You retrieve user input
- *  and pass it to the [DetectIntent][google.cloud.dialogflow.v2beta1.Sessions.DetectIntent] (or
- *  [StreamingDetectIntent][google.cloud.dialogflow.v2beta1.Sessions.StreamingDetectIntent]) method to determine
+ *  and pass it to the {@link google.cloud.dialogflow.v2beta1.Sessions.DetectIntent|DetectIntent} (or
+ *  {@link google.cloud.dialogflow.v2beta1.Sessions.StreamingDetectIntent|StreamingDetectIntent}) method to determine
  *  user intent and respond.
  * @class
  * @memberof v2beta1
@@ -44,8 +44,13 @@ export class SessionsClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  sessionsStub: Promise<{[name: string]: Function}>;
+  sessionsStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of SessionsClient.
@@ -69,8 +74,6 @@ export class SessionsClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -100,25 +103,28 @@ export class SessionsClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof SessionsClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -134,7 +140,7 @@ export class SessionsClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -142,22 +148,22 @@ export class SessionsClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      projectPathTemplate: new gaxModule.PathTemplate(
+      projectPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent'
       ),
-      projectIntentPathTemplate: new gaxModule.PathTemplate(
+      projectIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/intents/{intent}'
       ),
-      projectLocationPathTemplate: new gaxModule.PathTemplate(
+      projectLocationPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent'
       ),
-      projectLocationIntentPathTemplate: new gaxModule.PathTemplate(
+      projectLocationIntentPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent/intents/{intent}'
       ),
-      projectLocationSessionPathTemplate: new gaxModule.PathTemplate(
+      projectLocationSessionPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/locations/{location}/agent/sessions/{session}'
       ),
-      projectSessionPathTemplate: new gaxModule.PathTemplate(
+      projectSessionPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/agent/sessions/{session}'
       ),
     };
@@ -165,13 +171,13 @@ export class SessionsClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this._descriptors.stream = {
-      streamingDetectIntent: new gaxModule.StreamDescriptor(
+      streamingDetectIntent: new this._gaxModule.StreamDescriptor(
         gax.StreamType.BIDI_STREAMING
       ),
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.dialogflow.v2beta1.Sessions',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -182,17 +188,35 @@ export class SessionsClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.sessionsStub) {
+      return this.sessionsStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.dialogflow.v2beta1.Sessions.
-    this.sessionsStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.sessionsStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.dialogflow.v2beta1.Sessions'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.dialogflow.v2beta1.Sessions,
-      opts
+          (this._protos as any).google.cloud.dialogflow.v2beta1.Sessions,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -212,9 +236,9 @@ export class SessionsClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -228,6 +252,8 @@ export class SessionsClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.sessionsStub;
   }
 
   /**
@@ -340,11 +366,11 @@ export class SessionsClient {
    *   audio. If this field is not set and agent-level speech synthesizer is not
    *   configured, no output audio is generated.
    * @param {google.protobuf.FieldMask} request.outputAudioConfigMask
-   *   Mask for [output_audio_config][google.cloud.dialogflow.v2beta1.DetectIntentRequest.output_audio_config] indicating which settings in this
+   *   Mask for {@link google.cloud.dialogflow.v2beta1.DetectIntentRequest.output_audio_config|output_audio_config} indicating which settings in this
    *   request-level config should override speech synthesizer settings defined at
    *   agent-level.
    *
-   *   If unspecified or empty, [output_audio_config][google.cloud.dialogflow.v2beta1.DetectIntentRequest.output_audio_config] replaces the agent-level
+   *   If unspecified or empty, {@link google.cloud.dialogflow.v2beta1.DetectIntentRequest.output_audio_config|output_audio_config} replaces the agent-level
    *   config in its entirety.
    * @param {Buffer} request.inputAudio
    *   The natural language speech audio to be processed. This field
@@ -398,6 +424,7 @@ export class SessionsClient {
     ] = gax.routingHeader.fromParams({
       session: request.session || '',
     });
+    this.initialize();
     return this._innerApiCalls.detectIntent(request, options, callback);
   }
 
@@ -414,6 +441,7 @@ export class SessionsClient {
    *   will emit objects representing [StreamingDetectIntentResponse]{@link google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse} on 'data' event asynchronously.
    */
   streamingDetectIntent(options?: gax.CallOptions): gax.CancellableStream {
+    this.initialize();
     return this._innerApiCalls.streamingDetectIntent(options);
   }
 
@@ -692,8 +720,9 @@ export class SessionsClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.sessionsStub.then(stub => {
+      return this.sessionsStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,13 +1,13 @@
 {
-  "updateTime": "2020-03-04T12:24:39.711413Z",
+  "updateTime": "2020-03-05T23:06:26.077929Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "541b1ded4abadcc38e8178680b0677f65594ea6f",
-        "internalRef": "298686266",
-        "log": "541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n244ab2b83a82076a1fa7be63b7e0671af73f5c02\nAdds service config definition for bigqueryreservation v1\n\nPiperOrigin-RevId: 298455048\n\n"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282",
+        "log": "f0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\ndcc5d00fc8a8d8b56f16194d7c682027b2c66a3b\nfix: add java_multiple_files option for automl classification.proto\n\nPiperOrigin-RevId: 298953301\n\na3f791827266f3496a6a5201d58adc4bb265c2a3\nchore: automl/v1 publish annotations and retry config\n\nPiperOrigin-RevId: 298942178\n\n01c681586d8d6dbd60155289b587aee678530bd9\nMark return_immediately in PullRequest deprecated.\n\nPiperOrigin-RevId: 298893281\n\nc9f5e9c4bfed54bbd09227e990e7bded5f90f31c\nRemove out of date documentation for predicate support on the Storage API\n\nPiperOrigin-RevId: 298883309\n\nfd5b3b8238d783b04692a113ffe07c0363f5de0f\ngenerate webrisk v1 proto\n\nPiperOrigin-RevId: 298847934\n\n"
       }
     },
     {

--- a/test/gapic-agents-v2.ts
+++ b/test/gapic-agents-v2.ts
@@ -102,12 +102,30 @@ describe('v2.AgentsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new agentsModule.v2.AgentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.agentsStub, undefined);
+    await client.initialize();
+    assert(client.agentsStub);
+  });
+  it('has close method', () => {
+    const client = new agentsModule.v2.AgentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getAgent', () => {
     it('invokes getAgent without error', done => {
       const client = new agentsModule.v2.AgentsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetAgentRequest = {};
       request.parent = '';
@@ -131,6 +149,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetAgentRequest = {};
       request.parent = '';
@@ -156,6 +176,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ISetAgentRequest = {};
       request.agent = {};
@@ -180,6 +202,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ISetAgentRequest = {};
       request.agent = {};
@@ -206,6 +230,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteAgentRequest = {};
       request.parent = '';
@@ -229,6 +255,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteAgentRequest = {};
       request.parent = '';
@@ -254,6 +282,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetValidationResultRequest = {};
       request.parent = '';
@@ -277,6 +307,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetValidationResultRequest = {};
       request.parent = '';
@@ -302,6 +334,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ITrainAgentRequest = {};
       request.parent = '';
@@ -332,6 +366,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ITrainAgentRequest = {};
       request.parent = '';
@@ -365,6 +401,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IExportAgentRequest = {};
       request.parent = '';
@@ -395,6 +433,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IExportAgentRequest = {};
       request.parent = '';
@@ -428,6 +468,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IImportAgentRequest = {};
       request.parent = '';
@@ -458,6 +500,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IImportAgentRequest = {};
       request.parent = '';
@@ -491,6 +535,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IRestoreAgentRequest = {};
       request.parent = '';
@@ -521,6 +567,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IRestoreAgentRequest = {};
       request.parent = '';
@@ -554,6 +602,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ISearchAgentsRequest = {};
       request.parent = '';
@@ -581,6 +631,8 @@ describe('v2.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ISearchAgentsRequest = {};
       request.parent = '';

--- a/test/gapic-agents-v2beta1.ts
+++ b/test/gapic-agents-v2beta1.ts
@@ -81,12 +81,30 @@ describe('v2beta1.AgentsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new agentsModule.v2beta1.AgentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.agentsStub, undefined);
+    await client.initialize();
+    assert(client.agentsStub);
+  });
+  it('has close method', () => {
+    const client = new agentsModule.v2beta1.AgentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getAgent', () => {
     it('invokes getAgent without error', done => {
       const client = new agentsModule.v2beta1.AgentsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetAgentRequest = {};
       request.parent = '';
@@ -110,6 +128,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetAgentRequest = {};
       request.parent = '';
@@ -135,6 +155,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ISetAgentRequest = {};
       request.agent = {};
@@ -159,6 +181,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ISetAgentRequest = {};
       request.agent = {};
@@ -185,6 +209,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteAgentRequest = {};
       request.parent = '';
@@ -208,6 +234,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteAgentRequest = {};
       request.parent = '';
@@ -233,6 +261,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ITrainAgentRequest = {};
       request.parent = '';
@@ -256,6 +286,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ITrainAgentRequest = {};
       request.parent = '';
@@ -281,6 +313,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IExportAgentRequest = {};
       request.parent = '';
@@ -304,6 +338,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IExportAgentRequest = {};
       request.parent = '';
@@ -329,6 +365,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IImportAgentRequest = {};
       request.parent = '';
@@ -352,6 +390,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IImportAgentRequest = {};
       request.parent = '';
@@ -377,6 +417,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IRestoreAgentRequest = {};
       request.parent = '';
@@ -400,6 +442,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IRestoreAgentRequest = {};
       request.parent = '';
@@ -425,6 +469,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetValidationResultRequest = {};
       request.parent = '';
@@ -448,6 +494,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetValidationResultRequest = {};
       request.parent = '';
@@ -473,6 +521,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ISearchAgentsRequest = {};
       request.parent = '';
@@ -500,6 +550,8 @@ describe('v2beta1.AgentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ISearchAgentsRequest = {};
       request.parent = '';

--- a/test/gapic-contexts-v2.ts
+++ b/test/gapic-contexts-v2.ts
@@ -81,12 +81,30 @@ describe('v2.ContextsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new contextsModule.v2.ContextsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.contextsStub, undefined);
+    await client.initialize();
+    assert(client.contextsStub);
+  });
+  it('has close method', () => {
+    const client = new contextsModule.v2.ContextsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getContext', () => {
     it('invokes getContext without error', done => {
       const client = new contextsModule.v2.ContextsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetContextRequest = {};
       request.name = '';
@@ -110,6 +128,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetContextRequest = {};
       request.name = '';
@@ -135,6 +155,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateContextRequest = {};
       request.parent = '';
@@ -158,6 +180,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateContextRequest = {};
       request.parent = '';
@@ -183,6 +207,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateContextRequest = {};
       request.context = {};
@@ -207,6 +233,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateContextRequest = {};
       request.context = {};
@@ -233,6 +261,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteContextRequest = {};
       request.name = '';
@@ -256,6 +286,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteContextRequest = {};
       request.name = '';
@@ -281,6 +313,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteAllContextsRequest = {};
       request.parent = '';
@@ -304,6 +338,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteAllContextsRequest = {};
       request.parent = '';
@@ -329,6 +365,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListContextsRequest = {};
       request.parent = '';
@@ -356,6 +394,8 @@ describe('v2.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListContextsRequest = {};
       request.parent = '';

--- a/test/gapic-contexts-v2beta1.ts
+++ b/test/gapic-contexts-v2beta1.ts
@@ -81,12 +81,30 @@ describe('v2beta1.ContextsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new contextsModule.v2beta1.ContextsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.contextsStub, undefined);
+    await client.initialize();
+    assert(client.contextsStub);
+  });
+  it('has close method', () => {
+    const client = new contextsModule.v2beta1.ContextsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getContext', () => {
     it('invokes getContext without error', done => {
       const client = new contextsModule.v2beta1.ContextsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetContextRequest = {};
       request.name = '';
@@ -110,6 +128,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetContextRequest = {};
       request.name = '';
@@ -135,6 +155,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateContextRequest = {};
       request.parent = '';
@@ -158,6 +180,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateContextRequest = {};
       request.parent = '';
@@ -183,6 +207,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateContextRequest = {};
       request.context = {};
@@ -207,6 +233,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateContextRequest = {};
       request.context = {};
@@ -233,6 +261,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteContextRequest = {};
       request.name = '';
@@ -256,6 +286,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteContextRequest = {};
       request.name = '';
@@ -281,6 +313,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteAllContextsRequest = {};
       request.parent = '';
@@ -304,6 +338,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteAllContextsRequest = {};
       request.parent = '';
@@ -329,6 +365,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListContextsRequest = {};
       request.parent = '';
@@ -356,6 +394,8 @@ describe('v2beta1.ContextsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListContextsRequest = {};
       request.parent = '';

--- a/test/gapic-documents-v2beta1.ts
+++ b/test/gapic-documents-v2beta1.ts
@@ -81,12 +81,30 @@ describe('v2beta1.DocumentsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new documentsModule.v2beta1.DocumentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.documentsStub, undefined);
+    await client.initialize();
+    assert(client.documentsStub);
+  });
+  it('has close method', () => {
+    const client = new documentsModule.v2beta1.DocumentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getDocument', () => {
     it('invokes getDocument without error', done => {
       const client = new documentsModule.v2beta1.DocumentsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetDocumentRequest = {};
       request.name = '';
@@ -110,6 +128,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetDocumentRequest = {};
       request.name = '';
@@ -135,6 +155,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateDocumentRequest = {};
       request.parent = '';
@@ -158,6 +180,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateDocumentRequest = {};
       request.parent = '';
@@ -183,6 +207,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteDocumentRequest = {};
       request.name = '';
@@ -206,6 +232,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteDocumentRequest = {};
       request.name = '';
@@ -231,6 +259,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateDocumentRequest = {};
       request.document = {};
@@ -255,6 +285,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateDocumentRequest = {};
       request.document = {};
@@ -281,6 +313,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IReloadDocumentRequest = {};
       request.name = '';
@@ -304,6 +338,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IReloadDocumentRequest = {};
       request.name = '';
@@ -329,6 +365,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListDocumentsRequest = {};
       request.parent = '';
@@ -356,6 +394,8 @@ describe('v2beta1.DocumentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListDocumentsRequest = {};
       request.parent = '';

--- a/test/gapic-entity_types-v2.ts
+++ b/test/gapic-entity_types-v2.ts
@@ -102,12 +102,30 @@ describe('v2.EntityTypesClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new entitytypesModule.v2.EntityTypesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.entityTypesStub, undefined);
+    await client.initialize();
+    assert(client.entityTypesStub);
+  });
+  it('has close method', () => {
+    const client = new entitytypesModule.v2.EntityTypesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getEntityType', () => {
     it('invokes getEntityType without error', done => {
       const client = new entitytypesModule.v2.EntityTypesClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetEntityTypeRequest = {};
       request.name = '';
@@ -131,6 +149,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetEntityTypeRequest = {};
       request.name = '';
@@ -156,6 +176,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateEntityTypeRequest = {};
       request.parent = '';
@@ -179,6 +201,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateEntityTypeRequest = {};
       request.parent = '';
@@ -204,6 +228,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateEntityTypeRequest = {};
       request.entityType = {};
@@ -228,6 +254,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateEntityTypeRequest = {};
       request.entityType = {};
@@ -254,6 +282,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteEntityTypeRequest = {};
       request.name = '';
@@ -277,6 +307,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteEntityTypeRequest = {};
       request.name = '';
@@ -302,6 +334,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchUpdateEntityTypesRequest = {};
       request.parent = '';
@@ -332,6 +366,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchUpdateEntityTypesRequest = {};
       request.parent = '';
@@ -365,6 +401,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchDeleteEntityTypesRequest = {};
       request.parent = '';
@@ -395,6 +433,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchDeleteEntityTypesRequest = {};
       request.parent = '';
@@ -428,6 +468,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchCreateEntitiesRequest = {};
       request.parent = '';
@@ -458,6 +500,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchCreateEntitiesRequest = {};
       request.parent = '';
@@ -491,6 +535,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchUpdateEntitiesRequest = {};
       request.parent = '';
@@ -521,6 +567,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchUpdateEntitiesRequest = {};
       request.parent = '';
@@ -554,6 +602,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchDeleteEntitiesRequest = {};
       request.parent = '';
@@ -584,6 +634,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchDeleteEntitiesRequest = {};
       request.parent = '';
@@ -617,6 +669,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListEntityTypesRequest = {};
       request.parent = '';
@@ -644,6 +698,8 @@ describe('v2.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListEntityTypesRequest = {};
       request.parent = '';

--- a/test/gapic-entity_types-v2beta1.ts
+++ b/test/gapic-entity_types-v2beta1.ts
@@ -81,12 +81,30 @@ describe('v2beta1.EntityTypesClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new entitytypesModule.v2beta1.EntityTypesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.entityTypesStub, undefined);
+    await client.initialize();
+    assert(client.entityTypesStub);
+  });
+  it('has close method', () => {
+    const client = new entitytypesModule.v2beta1.EntityTypesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getEntityType', () => {
     it('invokes getEntityType without error', done => {
       const client = new entitytypesModule.v2beta1.EntityTypesClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetEntityTypeRequest = {};
       request.name = '';
@@ -110,6 +128,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetEntityTypeRequest = {};
       request.name = '';
@@ -135,6 +155,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateEntityTypeRequest = {};
       request.parent = '';
@@ -158,6 +180,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateEntityTypeRequest = {};
       request.parent = '';
@@ -183,6 +207,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateEntityTypeRequest = {};
       request.entityType = {};
@@ -207,6 +233,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateEntityTypeRequest = {};
       request.entityType = {};
@@ -233,6 +261,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteEntityTypeRequest = {};
       request.name = '';
@@ -256,6 +286,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteEntityTypeRequest = {};
       request.name = '';
@@ -281,6 +313,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchUpdateEntityTypesRequest = {};
       request.parent = '';
@@ -304,6 +338,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchUpdateEntityTypesRequest = {};
       request.parent = '';
@@ -329,6 +365,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchDeleteEntityTypesRequest = {};
       request.parent = '';
@@ -352,6 +390,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchDeleteEntityTypesRequest = {};
       request.parent = '';
@@ -377,6 +417,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchCreateEntitiesRequest = {};
       request.parent = '';
@@ -400,6 +442,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchCreateEntitiesRequest = {};
       request.parent = '';
@@ -425,6 +469,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchUpdateEntitiesRequest = {};
       request.parent = '';
@@ -448,6 +494,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchUpdateEntitiesRequest = {};
       request.parent = '';
@@ -473,6 +521,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchDeleteEntitiesRequest = {};
       request.parent = '';
@@ -496,6 +546,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchDeleteEntitiesRequest = {};
       request.parent = '';
@@ -521,6 +573,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListEntityTypesRequest = {};
       request.parent = '';
@@ -548,6 +602,8 @@ describe('v2beta1.EntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListEntityTypesRequest = {};
       request.parent = '';

--- a/test/gapic-intents-v2.ts
+++ b/test/gapic-intents-v2.ts
@@ -102,12 +102,30 @@ describe('v2.IntentsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new intentsModule.v2.IntentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.intentsStub, undefined);
+    await client.initialize();
+    assert(client.intentsStub);
+  });
+  it('has close method', () => {
+    const client = new intentsModule.v2.IntentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getIntent', () => {
     it('invokes getIntent without error', done => {
       const client = new intentsModule.v2.IntentsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetIntentRequest = {};
       request.name = '';
@@ -131,6 +149,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetIntentRequest = {};
       request.name = '';
@@ -156,6 +176,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateIntentRequest = {};
       request.parent = '';
@@ -179,6 +201,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateIntentRequest = {};
       request.parent = '';
@@ -204,6 +228,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateIntentRequest = {};
       request.intent = {};
@@ -228,6 +254,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateIntentRequest = {};
       request.intent = {};
@@ -254,6 +282,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteIntentRequest = {};
       request.name = '';
@@ -277,6 +307,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteIntentRequest = {};
       request.name = '';
@@ -302,6 +334,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchUpdateIntentsRequest = {};
       request.parent = '';
@@ -332,6 +366,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchUpdateIntentsRequest = {};
       request.parent = '';
@@ -365,6 +401,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchDeleteIntentsRequest = {};
       request.parent = '';
@@ -395,6 +433,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IBatchDeleteIntentsRequest = {};
       request.parent = '';
@@ -428,6 +468,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListIntentsRequest = {};
       request.parent = '';
@@ -455,6 +497,8 @@ describe('v2.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListIntentsRequest = {};
       request.parent = '';

--- a/test/gapic-intents-v2beta1.ts
+++ b/test/gapic-intents-v2beta1.ts
@@ -81,12 +81,30 @@ describe('v2beta1.IntentsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new intentsModule.v2beta1.IntentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.intentsStub, undefined);
+    await client.initialize();
+    assert(client.intentsStub);
+  });
+  it('has close method', () => {
+    const client = new intentsModule.v2beta1.IntentsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getIntent', () => {
     it('invokes getIntent without error', done => {
       const client = new intentsModule.v2beta1.IntentsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetIntentRequest = {};
       request.name = '';
@@ -110,6 +128,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetIntentRequest = {};
       request.name = '';
@@ -135,6 +155,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateIntentRequest = {};
       request.parent = '';
@@ -158,6 +180,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateIntentRequest = {};
       request.parent = '';
@@ -183,6 +207,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateIntentRequest = {};
       request.intent = {};
@@ -207,6 +233,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateIntentRequest = {};
       request.intent = {};
@@ -233,6 +261,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteIntentRequest = {};
       request.name = '';
@@ -256,6 +286,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteIntentRequest = {};
       request.name = '';
@@ -281,6 +313,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchUpdateIntentsRequest = {};
       request.parent = '';
@@ -304,6 +338,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchUpdateIntentsRequest = {};
       request.parent = '';
@@ -329,6 +365,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchDeleteIntentsRequest = {};
       request.parent = '';
@@ -352,6 +390,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IBatchDeleteIntentsRequest = {};
       request.parent = '';
@@ -377,6 +417,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListIntentsRequest = {};
       request.parent = '';
@@ -404,6 +446,8 @@ describe('v2beta1.IntentsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListIntentsRequest = {};
       request.parent = '';

--- a/test/gapic-knowledge_bases-v2beta1.ts
+++ b/test/gapic-knowledge_bases-v2beta1.ts
@@ -83,12 +83,30 @@ describe('v2beta1.KnowledgeBasesClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new knowledgebasesModule.v2beta1.KnowledgeBasesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.knowledgeBasesStub, undefined);
+    await client.initialize();
+    assert(client.knowledgeBasesStub);
+  });
+  it('has close method', () => {
+    const client = new knowledgebasesModule.v2beta1.KnowledgeBasesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getKnowledgeBase', () => {
     it('invokes getKnowledgeBase without error', done => {
       const client = new knowledgebasesModule.v2beta1.KnowledgeBasesClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetKnowledgeBaseRequest = {};
       request.name = '';
@@ -112,6 +130,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetKnowledgeBaseRequest = {};
       request.name = '';
@@ -137,6 +157,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateKnowledgeBaseRequest = {};
       request.parent = '';
@@ -160,6 +182,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateKnowledgeBaseRequest = {};
       request.parent = '';
@@ -185,6 +209,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteKnowledgeBaseRequest = {};
       request.name = '';
@@ -208,6 +234,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteKnowledgeBaseRequest = {};
       request.name = '';
@@ -233,6 +261,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateKnowledgeBaseRequest = {};
       request.knowledgeBase = {};
@@ -257,6 +287,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateKnowledgeBaseRequest = {};
       request.knowledgeBase = {};
@@ -283,6 +315,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListKnowledgeBasesRequest = {};
       request.parent = '';
@@ -310,6 +344,8 @@ describe('v2beta1.KnowledgeBasesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListKnowledgeBasesRequest = {};
       request.parent = '';

--- a/test/gapic-session_entity_types-v2.ts
+++ b/test/gapic-session_entity_types-v2.ts
@@ -83,12 +83,30 @@ describe('v2.SessionEntityTypesClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new sessionentitytypesModule.v2.SessionEntityTypesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.sessionEntityTypesStub, undefined);
+    await client.initialize();
+    assert(client.sessionEntityTypesStub);
+  });
+  it('has close method', () => {
+    const client = new sessionentitytypesModule.v2.SessionEntityTypesClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getSessionEntityType', () => {
     it('invokes getSessionEntityType without error', done => {
       const client = new sessionentitytypesModule.v2.SessionEntityTypesClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetSessionEntityTypeRequest = {};
       request.name = '';
@@ -112,6 +130,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IGetSessionEntityTypeRequest = {};
       request.name = '';
@@ -137,6 +157,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateSessionEntityTypeRequest = {};
       request.parent = '';
@@ -160,6 +182,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.ICreateSessionEntityTypeRequest = {};
       request.parent = '';
@@ -188,6 +212,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateSessionEntityTypeRequest = {};
       request.sessionEntityType = {};
@@ -212,6 +238,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IUpdateSessionEntityTypeRequest = {};
       request.sessionEntityType = {};
@@ -241,6 +269,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteSessionEntityTypeRequest = {};
       request.name = '';
@@ -264,6 +294,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDeleteSessionEntityTypeRequest = {};
       request.name = '';
@@ -292,6 +324,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListSessionEntityTypesRequest = {};
       request.parent = '';
@@ -319,6 +353,8 @@ describe('v2.SessionEntityTypesClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IListSessionEntityTypesRequest = {};
       request.parent = '';

--- a/test/gapic-session_entity_types-v2beta1.ts
+++ b/test/gapic-session_entity_types-v2beta1.ts
@@ -85,6 +85,26 @@ describe('v2beta1.SessionEntityTypesClient', () => {
     );
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new sessionentitytypesModule.v2beta1.SessionEntityTypesClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    assert.strictEqual(client.sessionEntityTypesStub, undefined);
+    await client.initialize();
+    assert(client.sessionEntityTypesStub);
+  });
+  it('has close method', () => {
+    const client = new sessionentitytypesModule.v2beta1.SessionEntityTypesClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    client.close();
+  });
   describe('getSessionEntityType', () => {
     it('invokes getSessionEntityType without error', done => {
       const client = new sessionentitytypesModule.v2beta1.SessionEntityTypesClient(
@@ -93,6 +113,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetSessionEntityTypeRequest = {};
       request.name = '';
@@ -118,6 +140,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IGetSessionEntityTypeRequest = {};
       request.name = '';
@@ -145,6 +169,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateSessionEntityTypeRequest = {};
       request.parent = '';
@@ -170,6 +196,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.ICreateSessionEntityTypeRequest = {};
       request.parent = '';
@@ -200,6 +228,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateSessionEntityTypeRequest = {};
       request.sessionEntityType = {};
@@ -226,6 +256,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IUpdateSessionEntityTypeRequest = {};
       request.sessionEntityType = {};
@@ -257,6 +289,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteSessionEntityTypeRequest = {};
       request.name = '';
@@ -282,6 +316,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDeleteSessionEntityTypeRequest = {};
       request.name = '';
@@ -312,6 +348,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListSessionEntityTypesRequest = {};
       request.parent = '';
@@ -341,6 +379,8 @@ describe('v2beta1.SessionEntityTypesClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IListSessionEntityTypesRequest = {};
       request.parent = '';

--- a/test/gapic-sessions-v2.ts
+++ b/test/gapic-sessions-v2.ts
@@ -103,12 +103,30 @@ describe('v2.SessionsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new sessionsModule.v2.SessionsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.sessionsStub, undefined);
+    await client.initialize();
+    assert(client.sessionsStub);
+  });
+  it('has close method', () => {
+    const client = new sessionsModule.v2.SessionsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('detectIntent', () => {
     it('invokes detectIntent without error', done => {
       const client = new sessionsModule.v2.SessionsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDetectIntentRequest = {};
       request.session = '';
@@ -132,6 +150,8 @@ describe('v2.SessionsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IDetectIntentRequest = {};
       request.session = '';
@@ -157,6 +177,8 @@ describe('v2.SessionsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IStreamingDetectIntentRequest = {};
       // Mock response
@@ -183,6 +205,8 @@ describe('v2.SessionsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2.IStreamingDetectIntentRequest = {};
       // Mock response

--- a/test/gapic-sessions-v2beta1.ts
+++ b/test/gapic-sessions-v2beta1.ts
@@ -103,12 +103,30 @@ describe('v2beta1.SessionsClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new sessionsModule.v2beta1.SessionsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.sessionsStub, undefined);
+    await client.initialize();
+    assert(client.sessionsStub);
+  });
+  it('has close method', () => {
+    const client = new sessionsModule.v2beta1.SessionsClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('detectIntent', () => {
     it('invokes detectIntent without error', done => {
       const client = new sessionsModule.v2beta1.SessionsClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDetectIntentRequest = {};
       request.session = '';
@@ -132,6 +150,8 @@ describe('v2beta1.SessionsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IDetectIntentRequest = {};
       request.session = '';
@@ -157,6 +177,8 @@ describe('v2beta1.SessionsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IStreamingDetectIntentRequest = {};
       // Mock response
@@ -183,6 +205,8 @@ describe('v2beta1.SessionsClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.dialogflow.v2beta1.IStreamingDetectIntentRequest = {};
       // Mock response


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.