### PR TITLE
docs: correct typo in comment

### DIFF
--- a/samples/detect.js
+++ b/samples/detect.js
@@ -22,8 +22,8 @@ function detectTextIntent(projectId, sessionId, queries, languageCode) {
    */
   // projectId: ID of the GCP project where Dialogflow agent is deployed
   // const projectId = 'PROJECT_ID';
-  // sessionId: Random number or hashed user identifier
-  // const sessionId = 123456;
+  // sessionId: String representing a random number or hashed user identifier 
+  // const sessionId = '123456';
   // queries: A set of sequential queries to be send to Dialogflow agent for Intent Detection
   // const queries = [
   //   'Reserve a meeting room in Toronto office, there will be 5 of us',


### PR DESCRIPTION
Using a `sessionId` as number, it causes the following error in `peg$parsetemplate`:

```
input.charCodeAt is not a function
```

Fixes #277
