### PR TITLE
test: don't enforce count

### DIFF
--- a/samples/system-test/list-session-entity-types.test.js
+++ b/samples/system-test/list-session-entity-types.test.js
@@ -68,7 +68,7 @@ describe('list session entity types', () => {
     const output = exec(`${cmd} list-session-entity-types -s ${sessionId}`);
     assert.include(output, sessionId);
     assert.include(output, displayName);
-    assert.include(output, '2');
+    assert.include(output, 'Number of entities');
   });
 
   after('delete the created entity type', async () => {


### PR DESCRIPTION
expecting a specific count can be flaky when multiple system tests are running in parallel.