### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v2/agents_client.ts
+++ b/src/v2/agents_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './agents_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -870,6 +870,39 @@ export class AgentsClient {
     this.initialize();
     return this.innerApiCalls.trainAgent(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the trainAgent() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkTrainAgentProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkTrainAgentProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.trainAgent,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
+  }
   exportAgent(
     request: protos.google.cloud.dialogflow.v2.IExportAgentRequest,
     options?: gax.CallOptions
@@ -975,6 +1008,42 @@ export class AgentsClient {
     });
     this.initialize();
     return this.innerApiCalls.exportAgent(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the exportAgent() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkExportAgentProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkExportAgentProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.dialogflow.v2.ExportAgentResponse,
+      protos.google.protobuf.Struct
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.exportAgent,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.dialogflow.v2.ExportAgentResponse,
+      protos.google.protobuf.Struct
+    >;
   }
   importAgent(
     request: protos.google.cloud.dialogflow.v2.IImportAgentRequest,
@@ -1086,6 +1155,39 @@ export class AgentsClient {
     this.initialize();
     return this.innerApiCalls.importAgent(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the importAgent() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkImportAgentProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkImportAgentProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.importAgent,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
+  }
   restoreAgent(
     request: protos.google.cloud.dialogflow.v2.IRestoreAgentRequest,
     options?: gax.CallOptions
@@ -1194,6 +1296,39 @@ export class AgentsClient {
     });
     this.initialize();
     return this.innerApiCalls.restoreAgent(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the restoreAgent() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRestoreAgentProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRestoreAgentProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.restoreAgent,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
   }
   searchAgents(
     request: protos.google.cloud.dialogflow.v2.ISearchAgentsRequest,

--- a/src/v2/entity_types_client.ts
+++ b/src/v2/entity_types_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './entity_types_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -944,6 +944,42 @@ export class EntityTypesClient {
       callback
     );
   }
+  /**
+   * Check the status of the long running operation returned by the batchUpdateEntityTypes() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchUpdateEntityTypesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchUpdateEntityTypesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.dialogflow.v2.BatchUpdateEntityTypesResponse,
+      protos.google.protobuf.Struct
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchUpdateEntityTypes,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.dialogflow.v2.BatchUpdateEntityTypesResponse,
+      protos.google.protobuf.Struct
+    >;
+  }
   batchDeleteEntityTypes(
     request: protos.google.cloud.dialogflow.v2.IBatchDeleteEntityTypesRequest,
     options?: gax.CallOptions
@@ -1051,6 +1087,39 @@ export class EntityTypesClient {
       options,
       callback
     );
+  }
+  /**
+   * Check the status of the long running operation returned by the batchDeleteEntityTypes() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchDeleteEntityTypesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchDeleteEntityTypesProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchDeleteEntityTypes,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
   }
   batchCreateEntities(
     request: protos.google.cloud.dialogflow.v2.IBatchCreateEntitiesRequest,
@@ -1160,6 +1229,39 @@ export class EntityTypesClient {
     });
     this.initialize();
     return this.innerApiCalls.batchCreateEntities(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the batchCreateEntities() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchCreateEntitiesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchCreateEntitiesProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchCreateEntities,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
   }
   batchUpdateEntities(
     request: protos.google.cloud.dialogflow.v2.IBatchUpdateEntitiesRequest,
@@ -1275,6 +1377,39 @@ export class EntityTypesClient {
     this.initialize();
     return this.innerApiCalls.batchUpdateEntities(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the batchUpdateEntities() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchUpdateEntitiesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchUpdateEntitiesProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchUpdateEntities,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
+  }
   batchDeleteEntities(
     request: protos.google.cloud.dialogflow.v2.IBatchDeleteEntitiesRequest,
     options?: gax.CallOptions
@@ -1386,6 +1521,39 @@ export class EntityTypesClient {
     });
     this.initialize();
     return this.innerApiCalls.batchDeleteEntities(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the batchDeleteEntities() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchDeleteEntitiesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchDeleteEntitiesProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchDeleteEntities,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
   }
   listEntityTypes(
     request: protos.google.cloud.dialogflow.v2.IListEntityTypesRequest,

--- a/src/v2/intents_client.ts
+++ b/src/v2/intents_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './intents_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -884,6 +884,42 @@ export class IntentsClient {
     this.initialize();
     return this.innerApiCalls.batchUpdateIntents(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the batchUpdateIntents() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchUpdateIntentsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchUpdateIntentsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.dialogflow.v2.BatchUpdateIntentsResponse,
+      protos.google.protobuf.Struct
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchUpdateIntents,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.dialogflow.v2.BatchUpdateIntentsResponse,
+      protos.google.protobuf.Struct
+    >;
+  }
   batchDeleteIntents(
     request: protos.google.cloud.dialogflow.v2.IBatchDeleteIntentsRequest,
     options?: gax.CallOptions
@@ -987,6 +1023,39 @@ export class IntentsClient {
     });
     this.initialize();
     return this.innerApiCalls.batchDeleteIntents(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the batchDeleteIntents() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchDeleteIntentsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchDeleteIntentsProgress(
+    name: string
+  ): Promise<
+    LROperation<protos.google.protobuf.Empty, protos.google.protobuf.Struct>
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchDeleteIntents,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.protobuf.Struct
+    >;
   }
   listIntents(
     request: protos.google.cloud.dialogflow.v2.IListIntentsRequest,

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-dialogflow.git",
-        "sha": "2d0e52f05253387299f15136349e261083fba39e"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1d520eaa7bbd8b40f53942ff03b5496fff887b53",
-        "internalRef": "307849529"
+        "remote": "git@github.com:googleapis/nodejs-dialogflow.git",
+        "sha": "9cec1beeace132829368b99701ce7c9970e4b126"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "716f741f2d307b48cbe8a5bc3bc883571212344a"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_agents_v2.ts
+++ b/test/gapic_agents_v2.ts
@@ -25,7 +25,7 @@ import * as agentsModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -326,9 +326,7 @@ describe('v2.AgentsClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getAgent = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getAgent(request);
-      }, expectedError);
+      await assert.rejects(client.getAgent(request), expectedError);
       assert(
         (client.innerApiCalls.getAgent as SinonStub)
           .getCall(0)
@@ -440,9 +438,7 @@ describe('v2.AgentsClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.setAgent = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.setAgent(request);
-      }, expectedError);
+      await assert.rejects(client.setAgent(request), expectedError);
       assert(
         (client.innerApiCalls.setAgent as SinonStub)
           .getCall(0)
@@ -554,9 +550,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteAgent(request);
-      }, expectedError);
+      await assert.rejects(client.deleteAgent(request), expectedError);
       assert(
         (client.innerApiCalls.deleteAgent as SinonStub)
           .getCall(0)
@@ -670,9 +664,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getValidationResult(request);
-      }, expectedError);
+      await assert.rejects(client.getValidationResult(request), expectedError);
       assert(
         (client.innerApiCalls.getValidationResult as SinonStub)
           .getCall(0)
@@ -792,9 +784,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.trainAgent(request);
-      }, expectedError);
+      await assert.rejects(client.trainAgent(request), expectedError);
       assert(
         (client.innerApiCalls.trainAgent as SinonStub)
           .getCall(0)
@@ -827,14 +817,50 @@ describe('v2.AgentsClient', () => {
         expectedError
       );
       const [operation] = await client.trainAgent(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.trainAgent as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkTrainAgentProgress without error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkTrainAgentProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkTrainAgentProgress with error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkTrainAgentProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -949,9 +975,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.exportAgent(request);
-      }, expectedError);
+      await assert.rejects(client.exportAgent(request), expectedError);
       assert(
         (client.innerApiCalls.exportAgent as SinonStub)
           .getCall(0)
@@ -984,14 +1008,50 @@ describe('v2.AgentsClient', () => {
         expectedError
       );
       const [operation] = await client.exportAgent(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.exportAgent as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkExportAgentProgress without error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkExportAgentProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkExportAgentProgress with error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkExportAgentProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1106,9 +1166,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.importAgent(request);
-      }, expectedError);
+      await assert.rejects(client.importAgent(request), expectedError);
       assert(
         (client.innerApiCalls.importAgent as SinonStub)
           .getCall(0)
@@ -1141,14 +1199,50 @@ describe('v2.AgentsClient', () => {
         expectedError
       );
       const [operation] = await client.importAgent(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.importAgent as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkImportAgentProgress without error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkImportAgentProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkImportAgentProgress with error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkImportAgentProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1263,9 +1357,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.restoreAgent(request);
-      }, expectedError);
+      await assert.rejects(client.restoreAgent(request), expectedError);
       assert(
         (client.innerApiCalls.restoreAgent as SinonStub)
           .getCall(0)
@@ -1298,14 +1390,50 @@ describe('v2.AgentsClient', () => {
         expectedError
       );
       const [operation] = await client.restoreAgent(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.restoreAgent as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRestoreAgentProgress without error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRestoreAgentProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRestoreAgentProgress with error', async () => {
+      const client = new agentsModule.v2.AgentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkRestoreAgentProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1416,9 +1544,7 @@ describe('v2.AgentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.searchAgents(request);
-      }, expectedError);
+      await assert.rejects(client.searchAgents(request), expectedError);
       assert(
         (client.innerApiCalls.searchAgents as SinonStub)
           .getCall(0)
@@ -1509,9 +1635,7 @@ describe('v2.AgentsClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.searchAgents.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_contexts_v2.ts
+++ b/test/gapic_contexts_v2.ts
@@ -297,9 +297,7 @@ describe('v2.ContextsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getContext(request);
-      }, expectedError);
+      await assert.rejects(client.getContext(request), expectedError);
       assert(
         (client.innerApiCalls.getContext as SinonStub)
           .getCall(0)
@@ -411,9 +409,7 @@ describe('v2.ContextsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createContext(request);
-      }, expectedError);
+      await assert.rejects(client.createContext(request), expectedError);
       assert(
         (client.innerApiCalls.createContext as SinonStub)
           .getCall(0)
@@ -528,9 +524,7 @@ describe('v2.ContextsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateContext(request);
-      }, expectedError);
+      await assert.rejects(client.updateContext(request), expectedError);
       assert(
         (client.innerApiCalls.updateContext as SinonStub)
           .getCall(0)
@@ -642,9 +636,7 @@ describe('v2.ContextsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteContext(request);
-      }, expectedError);
+      await assert.rejects(client.deleteContext(request), expectedError);
       assert(
         (client.innerApiCalls.deleteContext as SinonStub)
           .getCall(0)
@@ -756,9 +748,7 @@ describe('v2.ContextsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteAllContexts(request);
-      }, expectedError);
+      await assert.rejects(client.deleteAllContexts(request), expectedError);
       assert(
         (client.innerApiCalls.deleteAllContexts as SinonStub)
           .getCall(0)
@@ -874,9 +864,7 @@ describe('v2.ContextsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listContexts(request);
-      }, expectedError);
+      await assert.rejects(client.listContexts(request), expectedError);
       assert(
         (client.innerApiCalls.listContexts as SinonStub)
           .getCall(0)
@@ -967,9 +955,7 @@ describe('v2.ContextsClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listContexts.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_entity_types_v2.ts
+++ b/test/gapic_entity_types_v2.ts
@@ -25,7 +25,7 @@ import * as entitytypesModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -329,9 +329,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getEntityType(request);
-      }, expectedError);
+      await assert.rejects(client.getEntityType(request), expectedError);
       assert(
         (client.innerApiCalls.getEntityType as SinonStub)
           .getCall(0)
@@ -443,9 +441,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createEntityType(request);
-      }, expectedError);
+      await assert.rejects(client.createEntityType(request), expectedError);
       assert(
         (client.innerApiCalls.createEntityType as SinonStub)
           .getCall(0)
@@ -560,9 +556,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateEntityType(request);
-      }, expectedError);
+      await assert.rejects(client.updateEntityType(request), expectedError);
       assert(
         (client.innerApiCalls.updateEntityType as SinonStub)
           .getCall(0)
@@ -674,9 +668,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteEntityType(request);
-      }, expectedError);
+      await assert.rejects(client.deleteEntityType(request), expectedError);
       assert(
         (client.innerApiCalls.deleteEntityType as SinonStub)
           .getCall(0)
@@ -798,9 +790,10 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchUpdateEntityTypes(request);
-      }, expectedError);
+      await assert.rejects(
+        client.batchUpdateEntityTypes(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.batchUpdateEntityTypes as SinonStub)
           .getCall(0)
@@ -833,14 +826,53 @@ describe('v2.EntityTypesClient', () => {
         expectedError
       );
       const [operation] = await client.batchUpdateEntityTypes(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchUpdateEntityTypes as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchUpdateEntityTypesProgress without error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchUpdateEntityTypesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchUpdateEntityTypesProgress with error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchUpdateEntityTypesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -957,9 +989,10 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchDeleteEntityTypes(request);
-      }, expectedError);
+      await assert.rejects(
+        client.batchDeleteEntityTypes(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.batchDeleteEntityTypes as SinonStub)
           .getCall(0)
@@ -992,14 +1025,53 @@ describe('v2.EntityTypesClient', () => {
         expectedError
       );
       const [operation] = await client.batchDeleteEntityTypes(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchDeleteEntityTypes as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchDeleteEntityTypesProgress without error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchDeleteEntityTypesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchDeleteEntityTypesProgress with error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchDeleteEntityTypesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1116,9 +1188,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchCreateEntities(request);
-      }, expectedError);
+      await assert.rejects(client.batchCreateEntities(request), expectedError);
       assert(
         (client.innerApiCalls.batchCreateEntities as SinonStub)
           .getCall(0)
@@ -1151,14 +1221,53 @@ describe('v2.EntityTypesClient', () => {
         expectedError
       );
       const [operation] = await client.batchCreateEntities(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchCreateEntities as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchCreateEntitiesProgress without error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchCreateEntitiesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchCreateEntitiesProgress with error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchCreateEntitiesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1275,9 +1384,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchUpdateEntities(request);
-      }, expectedError);
+      await assert.rejects(client.batchUpdateEntities(request), expectedError);
       assert(
         (client.innerApiCalls.batchUpdateEntities as SinonStub)
           .getCall(0)
@@ -1310,14 +1417,53 @@ describe('v2.EntityTypesClient', () => {
         expectedError
       );
       const [operation] = await client.batchUpdateEntities(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchUpdateEntities as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchUpdateEntitiesProgress without error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchUpdateEntitiesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchUpdateEntitiesProgress with error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchUpdateEntitiesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1434,9 +1580,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchDeleteEntities(request);
-      }, expectedError);
+      await assert.rejects(client.batchDeleteEntities(request), expectedError);
       assert(
         (client.innerApiCalls.batchDeleteEntities as SinonStub)
           .getCall(0)
@@ -1469,14 +1613,53 @@ describe('v2.EntityTypesClient', () => {
         expectedError
       );
       const [operation] = await client.batchDeleteEntities(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchDeleteEntities as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchDeleteEntitiesProgress without error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchDeleteEntitiesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchDeleteEntitiesProgress with error', async () => {
+      const client = new entitytypesModule.v2.EntityTypesClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchDeleteEntitiesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1599,9 +1782,7 @@ describe('v2.EntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listEntityTypes(request);
-      }, expectedError);
+      await assert.rejects(client.listEntityTypes(request), expectedError);
       assert(
         (client.innerApiCalls.listEntityTypes as SinonStub)
           .getCall(0)
@@ -1698,9 +1879,7 @@ describe('v2.EntityTypesClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listEntityTypes.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_environments_v2.ts
+++ b/test/gapic_environments_v2.ts
@@ -313,9 +313,7 @@ describe('v2.EnvironmentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listEnvironments(request);
-      }, expectedError);
+      await assert.rejects(client.listEnvironments(request), expectedError);
       assert(
         (client.innerApiCalls.listEnvironments as SinonStub)
           .getCall(0)
@@ -412,9 +410,7 @@ describe('v2.EnvironmentsClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listEnvironments.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_intents_v2.ts
+++ b/test/gapic_intents_v2.ts
@@ -25,7 +25,7 @@ import * as intentsModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -326,9 +326,7 @@ describe('v2.IntentsClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getIntent = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getIntent(request);
-      }, expectedError);
+      await assert.rejects(client.getIntent(request), expectedError);
       assert(
         (client.innerApiCalls.getIntent as SinonStub)
           .getCall(0)
@@ -440,9 +438,7 @@ describe('v2.IntentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createIntent(request);
-      }, expectedError);
+      await assert.rejects(client.createIntent(request), expectedError);
       assert(
         (client.innerApiCalls.createIntent as SinonStub)
           .getCall(0)
@@ -557,9 +553,7 @@ describe('v2.IntentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateIntent(request);
-      }, expectedError);
+      await assert.rejects(client.updateIntent(request), expectedError);
       assert(
         (client.innerApiCalls.updateIntent as SinonStub)
           .getCall(0)
@@ -671,9 +665,7 @@ describe('v2.IntentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteIntent(request);
-      }, expectedError);
+      await assert.rejects(client.deleteIntent(request), expectedError);
       assert(
         (client.innerApiCalls.deleteIntent as SinonStub)
           .getCall(0)
@@ -795,9 +787,7 @@ describe('v2.IntentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchUpdateIntents(request);
-      }, expectedError);
+      await assert.rejects(client.batchUpdateIntents(request), expectedError);
       assert(
         (client.innerApiCalls.batchUpdateIntents as SinonStub)
           .getCall(0)
@@ -830,14 +820,53 @@ describe('v2.IntentsClient', () => {
         expectedError
       );
       const [operation] = await client.batchUpdateIntents(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchUpdateIntents as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchUpdateIntentsProgress without error', async () => {
+      const client = new intentsModule.v2.IntentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchUpdateIntentsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchUpdateIntentsProgress with error', async () => {
+      const client = new intentsModule.v2.IntentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchUpdateIntentsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -954,9 +983,7 @@ describe('v2.IntentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchDeleteIntents(request);
-      }, expectedError);
+      await assert.rejects(client.batchDeleteIntents(request), expectedError);
       assert(
         (client.innerApiCalls.batchDeleteIntents as SinonStub)
           .getCall(0)
@@ -989,14 +1016,53 @@ describe('v2.IntentsClient', () => {
         expectedError
       );
       const [operation] = await client.batchDeleteIntents(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchDeleteIntents as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchDeleteIntentsProgress without error', async () => {
+      const client = new intentsModule.v2.IntentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchDeleteIntentsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchDeleteIntentsProgress with error', async () => {
+      const client = new intentsModule.v2.IntentsClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchDeleteIntentsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1107,9 +1173,7 @@ describe('v2.IntentsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listIntents(request);
-      }, expectedError);
+      await assert.rejects(client.listIntents(request), expectedError);
       assert(
         (client.innerApiCalls.listIntents as SinonStub)
           .getCall(0)
@@ -1199,9 +1263,7 @@ describe('v2.IntentsClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listIntents.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_session_entity_types_v2.ts
+++ b/test/gapic_session_entity_types_v2.ts
@@ -301,9 +301,7 @@ describe('v2.SessionEntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getSessionEntityType(request);
-      }, expectedError);
+      await assert.rejects(client.getSessionEntityType(request), expectedError);
       assert(
         (client.innerApiCalls.getSessionEntityType as SinonStub)
           .getCall(0)
@@ -417,9 +415,10 @@ describe('v2.SessionEntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createSessionEntityType(request);
-      }, expectedError);
+      await assert.rejects(
+        client.createSessionEntityType(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.createSessionEntityType as SinonStub)
           .getCall(0)
@@ -536,9 +535,10 @@ describe('v2.SessionEntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateSessionEntityType(request);
-      }, expectedError);
+      await assert.rejects(
+        client.updateSessionEntityType(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.updateSessionEntityType as SinonStub)
           .getCall(0)
@@ -652,9 +652,10 @@ describe('v2.SessionEntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteSessionEntityType(request);
-      }, expectedError);
+      await assert.rejects(
+        client.deleteSessionEntityType(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.deleteSessionEntityType as SinonStub)
           .getCall(0)
@@ -786,9 +787,10 @@ describe('v2.SessionEntityTypesClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listSessionEntityTypes(request);
-      }, expectedError);
+      await assert.rejects(
+        client.listSessionEntityTypes(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.listSessionEntityTypes as SinonStub)
           .getCall(0)
@@ -886,9 +888,7 @@ describe('v2.SessionEntityTypesClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listSessionEntityTypes
           .createStream as SinonStub)

--- a/test/gapic_sessions_v2.ts
+++ b/test/gapic_sessions_v2.ts
@@ -250,9 +250,7 @@ describe('v2.SessionsClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.detectIntent(request);
-      }, expectedError);
+      await assert.rejects(client.detectIntent(request), expectedError);
       assert(
         (client.innerApiCalls.detectIntent as SinonStub)
           .getCall(0)
@@ -338,9 +336,7 @@ describe('v2.SessionsClient', () => {
         stream.write(request);
         stream.end();
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.innerApiCalls.streamingDetectIntent as SinonStub)
           .getCall(0)


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkBatchCreateEntitiesProgress`, `checkBatchDeleteEntitiesProgress`,`checkBatchDeleteEntityTypesProgress`,`checkBatchDeleteIntentsProgress`,`checkBatchUpdateEntitiesProgress`,`checkBatchUpdateEntityTypesProgress`,`checkBatchUpdateIntentsProgress`,`checkExportAgentProgress`,`checkImportAgentProgress`,`checkRestoreAgentProgress`,`checkTrainAgentProgress`,.