### PR TITLE
fix: npm package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 ### Installing the client library
 
 ```bash
-npm install dialogflow
+npm install @google-cloud/dialogflow
 ```
 
 


### PR DESCRIPTION
It was still the old one, see for example https://stackoverflow.com/questions/63177431/node-and-dialogflow-error-unhandledpromiserejectionwarning-typeerror-sessionc and https://www.npmjs.com/package/@google-cloud/dialogflow

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-dialogflow/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #677 🦕
